### PR TITLE
Changed references.js so that translations of references fallback to english

### DIFF
--- a/content/references/translations/de/processing/bezier().de.json
+++ b/content/references/translations/de/processing/bezier().de.json
@@ -3,7 +3,7 @@
   "related": ["bezierVertex_.html", "curve_.html"],
   "usage": "",
   "name": "bezier()",
-  "description": "( begin auto-generated from bezier.xml )\n\n Draws a Bezier curve on the screen. These curves are defined by a series\n of anchor and control points. The first two parameters specify the first\n anchor point and the last two parameters specify the other anchor point.\n The middle parameters specify the control points which define the shape\n of the curve. Bezier curves were developed by French engineer Pierre\n Bezier. Using the 3D version requires rendering with P3D (see the\n Environment reference for more information).\n\n ( end auto-generated )\n\n ",
+  "description": " DE ( begin auto-generated from bezier.xml )\n\n Draws a Bezier curve on the screen. These curves are defined by a series\n of anchor and control points. The first two parameters specify the first\n anchor point and the last two parameters specify the other anchor point.\n The middle parameters specify the control points which define the shape\n of the curve. Bezier curves were developed by French engineer Pierre\n Bezier. Using the 3D version requires rendering with P3D (see the\n Environment reference for more information).\n\n ( end auto-generated )\n\n ",
   "syntax": [
     "bezier(x1, y1, x2, y2, x3, y3, x4, y4)",
     "bezier(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4)"

--- a/src/pages/references.js
+++ b/src/pages/references.js
@@ -18,9 +18,9 @@ const References = ({ data }) => {
 export default References;
 
 export const query = graphql`
-  query($locale: String!) {
+  query {
     allFile(
-      filter: { fields: { lang: { eq: $locale }, lib: { eq: "processing" } } }
+      filter: { fields: { lang: { eq: "en" }, lib: { eq: "processing" } } }
     ) {
       nodes {
         name


### PR DESCRIPTION
This PR changes `references.js ` so that translations of references fallback to english if they are missing