### PR TITLE
Rewriting GraphQL logic on front page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -265,7 +265,7 @@ async function createExamples(actions, graphql) {
         json: allFile(
           filter: {
             sourceInstanceName: { eq: "examples" }
-            extension: { regex: "/(json)/" }
+            extension: { eq: "json" }
           }
         ) {
           edges {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10073,11 +10073,6 @@
         "minipass": "^3.0.0"
       }
     },
-    "fs-readdir-recursive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
-    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -21048,14 +21043,6 @@
             "to-regex": "^3.0.2"
           }
         }
-      }
-    },
-    "recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
-      "requires": {
-        "minimatch": "3.0.4"
       }
     },
     "redent": {

--- a/src/hooks/examples.js
+++ b/src/hooks/examples.js
@@ -16,20 +16,25 @@ export const useOrderedPdes = (name, nodes) => {
 
 /**
   Hook to find the json and image for each related example
-  @param {Array} related Array of strings with names of related examples
-  @param {Array} examples Array of all example JSON files returned from GraphQL
+  @param {Array} examples Array of example JSON files
   @param {Array} images Array of sharp image objects
+  @param {Array} filter Array of strings with names to filter examples by
 **/
-export const useRelatedExamples = (related, examples, images) => {
+export const usePreparedExamples = (examples, images, filter) => {
   return useMemo(() => {
-    return related.map((name) => {
-      const json = examples.find((f) => f.name === name);
-      const image = images.find((f) => f.name === name);
+    const filtered = filter
+      ? examples.filter((f) => filter.includes(f.name))
+      : examples;
+    return filtered.map((example) => {
+      const image = images.find((f) => f.name === example.name);
+      const [category, subCategory] = example.relativeDirectory.split('/');
       return {
-        slug: examplePath(name),
-        name: json.childJson.name,
+        slug: examplePath(example.name),
+        name: example.childJson.name,
+        category,
+        subCategory,
         image,
       };
     });
-  }, [related, examples, images]);
+  }, [examples, images, filter]);
 };

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,14 +1,29 @@
 import {
   useEffect,
   useRef,
+  useMemo,
   useLayoutEffect,
   useCallback,
   useState,
 } from 'react';
 import hljs from 'highlight.js/lib/core';
 import processing from 'highlight.js/lib/languages/processing';
+import { shuffleArray } from '../utils/data';
 
 hljs.registerLanguage('processing', processing);
+
+/**
+  Hook to get random items from an array
+  @param {Array} arr Array of items
+  @param {number} num Number of items to select
+**/
+export const useRandomArray = (arr, num) => {
+  return useMemo(() => {
+    const copy = arr.slice();
+    shuffleArray(copy);
+    return num && num < copy.length ? copy.slice(0, num) : copy;
+  }, [arr, num]);
+};
 
 export const useHighlight = () => {
   const ref = useRef();

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
+import { graphql } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
@@ -10,7 +11,8 @@ import Button from '../components/Button';
 import Card from '../components/Card';
 import Sketch from '../components/sketch/Sketch';
 
-import { shuffleArray, subcategoryFromDirectory } from '../utils/data';
+import { useRandomArray } from '../hooks';
+import { usePreparedExamples } from '../hooks/examples';
 
 import css from '../styles/pages/index.module.css';
 import grid from '../styles/grid.module.css';
@@ -44,60 +46,20 @@ export const items = [
   },
 ];
 
-const preselected = [
-  'keyboardfunctions',
-  'radialgradient',
-  'saturation',
-  'gameoflife',
-  'loadingimages',
-  'rotatepushpop',
-  'spot',
-  'lineargradient',
-  'penrosesnowflake',
-  'multipleparticlesystems',
-];
-
 const IndexPage = ({ data }) => {
   const intl = useIntl();
   const { locale } = useLocalization();
 
-  const items = data.examples.nodes;
-  const images = data.images.nodes;
-
-  const examples = useMemo(
-    () =>
-      items.map((item, i) => {
-        const image = images
-          ? images.find(
-              (img) => img.relativeDirectory === item.relativeDirectory
-            )
-          : '';
-        const [cat, subcat, slug] = item.relativeDirectory.split('/');
-        return {
-          slug: slug,
-          subcat: subcat,
-          cat: cat,
-          name: item.name,
-          dir: item.relativeDirectory,
-          img: image,
-        };
-      }),
-    [items, images]
+  const featuredExamples = usePreparedExamples(
+    data.examples.nodes,
+    data.exampleImages.nodes
   );
-
-  const selectedExamples = useMemo(() => {
-    const filteredExamples = examples
-      ? examples.filter((d) => preselected.includes(d.slug.toLowerCase()))
-      : [];
-    shuffleArray(filteredExamples);
-    const random = filteredExamples.slice(0, 4);
-    return random;
-  }, [examples]);
+  const randomExamples = useRandomArray(featuredExamples, 4);
 
   return (
     <Layout isHomepage>
       <Helmet>
-        <title>{'Welcome to Processing!'}</title>
+        <title>Welcome to Processing!</title>
       </Helmet>
       <div className={classnames(css.hero, grid.grid, grid.rightBleed)}>
         <div className={classnames(grid.col, css.intro)}>
@@ -120,37 +82,11 @@ const IndexPage = ({ data }) => {
         </div>
         <Sketch />
       </div>
-      <div className={classnames(grid.grid, css.section)}>
-        <div className={classnames(grid.col, grid.nest, css.examples)}>
-          <h3 className={grid.col}>{intl.formatMessage({ id: 'examples' })}</h3>
-          <ul>
-            {selectedExamples.map((example, i) => (
-              <li
-                className={classnames(css.example, grid.col)}
-                key={`example-${example.slug}`}>
-                <Link
-                  to={`/examples/${example.slug.toLowerCase()}.html`}
-                  language={locale}>
-                  <div
-                    className={css.imgContainer}
-                    key={`exampleImgContainer-${i}`}>
-                    {example.img && (
-                      <Img fluid={example.img.childImageSharp.fluid} />
-                    )}
-                  </div>
-                  <h4>{example.name}</h4>
-                  <p>{`in ${subcategoryFromDirectory(
-                    example.dir
-                  )} examples`}</p>
-                </Link>
-              </li>
-            ))}
-          </ul>
-          <div className={classnames(grid.col, css.moreButton)}>
-            <Button to={'/examples'}>More Examples</Button>
-          </div>
-        </div>
-      </div>
+      <FeaturedExamples
+        examples={randomExamples}
+        heading={intl.formatMessage({ id: 'examples' })}
+        locale={locale}
+      />
       <div className={css.sectionDivider} />
       <div className={classnames(grid.grid, css.section)}>
         <div className={classnames(grid.col, css.half)}>
@@ -294,14 +230,60 @@ const IndexPage = ({ data }) => {
   );
 };
 
+const FeaturedExamples = memo(({ heading, examples, locale }) => {
+  return (
+    <div className={classnames(grid.grid, css.section)}>
+      <div className={classnames(grid.col, grid.nest, css.examples)}>
+        <h3 className={grid.col}>{heading}</h3>
+        <ul>
+          {examples.map((example, i) => (
+            <li
+              className={classnames(css.example, grid.col)}
+              key={example.slug}>
+              <Link to={example.slug} language={locale}>
+                <div className={css.imgContainer}>
+                  {example.image && (
+                    <Img fluid={example.image.childImageSharp.fluid} />
+                  )}
+                </div>
+                <h4>{example.name}</h4>
+                <p>in {example.subCategory} examples</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <div className={classnames(grid.col, css.moreButton)}>
+          <Button to={'/examples'}>More Examples</Button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
 export default IndexPage;
 
 export const query = graphql`
-  query {
+  query(
+    $featuredExamples: [String] = [
+      "KeyboardFunctions"
+      "RadialGradient"
+      "Saturation"
+      "GameOfLife"
+      "LoadingImages"
+      "RotatePushPop"
+      "Spot"
+      "LinearGradient"
+      "PenroseSnowflake"
+      "MultipleParticleSystems"
+    ]
+  ) {
     examples: allFile(
       filter: {
+        name: { in: $featuredExamples }
+        extension: { eq: "json" }
         sourceInstanceName: { eq: "examples" }
         fields: { lang: { eq: "en" } }
+        dir: { regex: "/.*[^data]$/" }
       }
       sort: { order: ASC, fields: relativeDirectory }
     ) {
@@ -315,8 +297,9 @@ export const query = graphql`
         }
       }
     }
-    images: allFile(
+    exampleImages: allFile(
       filter: {
+        name: { in: $featuredExamples }
         sourceInstanceName: { eq: "examples" }
         extension: { regex: "/(jpg)|(jpeg)|(png)|(gif)/" }
         dir: { regex: "/.*[^data]$/" }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -114,11 +114,6 @@ export const organizeExampleItems = (items, images) => {
   return tree;
 };
 
-export const subcategoryFromDirectory = (relDir) => {
-  const category = relDir.split('/')[1];
-  return category.charAt(0).toUpperCase() + category.slice(1);
-};
-
 export const shuffleArray = (array) => {
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));


### PR DESCRIPTION
This PR rewrites the front page GraphQL logic inspired by the `/examples` pages. 

- **Load less GraphQL items**. The big change is that the array of featured examples was moved to a GraphQL variable, so we can query only those examples and images. This makes sure that we don't load all 160 examples only to use a few of them.

- **Clean up logic**. I also cleaned up the logic of extracting data and image for each example in the `usePreparedExamples` hook, which is now shared between the examples pages and the front page.

- **Load less items in examples**. Finally, I made sure that we're only loading `.json` files from the examples, so we don't get extra files from the `data` folder, etc.

Otherwise the logic stays the same!