### PR TITLE
Adding in use examples to references

### DIFF
--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -99,6 +99,7 @@
   "fields": "Fields",
   "methods": "Methods",
   "related": "Related",
+  "inUse": "In use",
   "notTranslated": "This page is not translated, please refer to the",
   "englishPage": "english page",
   "featured": "Featured functions",

--- a/src/components/ExamplesList.js
+++ b/src/components/ExamplesList.js
@@ -66,7 +66,7 @@ const ExamplesList = ({ tree }) => {
   );
 };
 
-const ExampleItem = memo(({ node, locale }) => {
+export const ExampleItem = memo(({ node, locale }) => {
   return (
     <li className={grid.col}>
       <Link to={node.path} language={locale}>

--- a/src/hooks/reference.js
+++ b/src/hooks/reference.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { titleCase } from '../utils';
-import { referencePath, pathToName } from '../utils/paths';
+import { referencePath, pathToName, examplePath } from '../utils/paths';
 
 /**
   Hook to turn the reference items in an object that can be used in useTree
@@ -17,7 +17,7 @@ export const usePreparedItems = (items, libraryName) => {
         path: referencePath(item.name, libraryName),
         category: titleCase(item.childJson.category),
         subcategory: titleCase(item.childJson.subcategory),
-        search: `${item.childJson.name} ${item.childJson.brief ?? ''}`,
+        search: `${item.childJson.name} ${item.childJson.brief ?? ''}`
       })
     );
   }, [items, libraryName]);
@@ -36,7 +36,7 @@ export const usePreparedList = (items, libraryName, nameIsPath, shouldLink) => {
     // Convert string to a list object
     const stringToListObject = (str) => {
       const obj = {
-        name: nameIsPath ? pathToName(str) : str,
+        name: nameIsPath ? pathToName(str) : str
       };
 
       if (shouldLink) {
@@ -49,7 +49,7 @@ export const usePreparedList = (items, libraryName, nameIsPath, shouldLink) => {
     const objectToListObject = (old) => {
       const obj = {
         name: nameIsPath ? pathToName(old.name) : old.name,
-        description: old.description ?? old.desc,
+        description: old.description ?? old.desc
       };
       if (old.type) {
         obj.type = old.type;
@@ -93,7 +93,7 @@ export const usePreparedExamples = (pdes, images) => {
     const prepared = [];
     for (let i = 0; i < pdes.length; i++) {
       const example = {
-        code: pdes[i].node.internal.content,
+        code: pdes[i].node.internal.content
       };
 
       if (images) {
@@ -110,4 +110,36 @@ export const usePreparedExamples = (pdes, images) => {
 
     return prepared;
   }, [pdes, images]);
+};
+
+/**
+  Hook to prepare every in use example and find an image for it
+  @param {Array} examples GraphQL in use examples
+  @param {Array} images GraphQL image nodes
+**/
+export const useInUseExamples = (inUseExamples, images) => {
+  return useMemo(() => {
+    if (!inUseExamples || inUseExamples.length === 0) {
+      return null;
+    }
+    const prepared = [];
+    for (let i = 0; i < inUseExamples.length; i++) {
+      const example = {
+        name: inUseExamples[i].split(/(?=[A-Z])/).join(' '),
+        path: examplePath(inUseExamples[i])
+      };
+
+      if (images) {
+        for (let j = 0; j < images.nodes.length; j++) {
+          if (images.nodes[j].name === inUseExamples[i]) {
+            example.image = images.nodes[j];
+            break;
+          }
+        }
+      }
+
+      prepared.push(example);
+    }
+    return prepared;
+  }, [inUseExamples, images]);
 };

--- a/src/styles/templates/examples/example.module.css
+++ b/src/styles/templates/examples/example.module.css
@@ -41,6 +41,12 @@
   }
 }
 
+.inuse {
+  & li {
+    flex-basis: cols(1, 3);
+  }
+}
+
 .img {
   width: 100%;
   min-height: 100px;

--- a/src/templates/reference/field.js
+++ b/src/templates/reference/field.js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import { Link } from 'gatsby';
 import { useIntl } from 'react-intl';
+import classnames from 'classnames';
 
 import Layout from '../../components/Layout';
 import Content from '../../components/ContentWithSidebar';
@@ -10,16 +11,19 @@ import Sidebar from '../../components/Sidebar';
 import Section from '../../components/ReferenceItemSection';
 import License from '../../components/ReferenceLicense';
 import { CodeList, ExampleList } from '../../components/ReferenceItemList';
+import { ExampleItem } from '../../components/ExamplesList';
 
 import { useTree, useHighlight, useWindowSize } from '../../hooks';
 import {
   usePreparedItems,
   usePreparedExamples,
   usePreparedList,
+  useInUseExamples
 } from '../../hooks/reference';
 import { referencePath } from '../../utils/paths';
 
 import grid from '../../styles/grid.module.css';
+import css from '../../styles/templates/examples/example.module.css';
 
 const FieldRefTemplate = ({ data, pageContext }) => {
   const entry = data?.json?.childJson;
@@ -38,6 +42,12 @@ const FieldRefTemplate = ({ data, pageContext }) => {
   const parameters = usePreparedList(entry?.parameters, libraryName);
   const syntax = usePreparedList(entry?.syntax, libraryName);
   const related = usePreparedList(entry?.related, libraryName, true, true);
+  const inUseExamples = useInUseExamples(
+    pageContext.inUseExamples,
+    data.inUseImages
+  );
+
+  console.log(pageContext.inUseExamples);
 
   const title = entry?.classanchor
     ? `${entry.classanchor}::${entry.name}`
@@ -84,6 +94,15 @@ const FieldRefTemplate = ({ data, pageContext }) => {
                 <CodeList items={related} />
               </Section>
             )}
+            {inUseExamples && (
+              <Section title={intl.formatMessage({ id: 'inUse' })}>
+                <ul className={classnames(css.related, css.inuse)}>
+                  {inUseExamples.slice(0, 6).map((e, key) => (
+                    <ExampleItem node={e} key={`e-${e.name}`} />
+                  ))}
+                </ul>
+              </Section>
+            )}
             <License />
           </Content>
         ) : (
@@ -103,7 +122,7 @@ const FieldRefTemplate = ({ data, pageContext }) => {
 export default FieldRefTemplate;
 
 export const query = graphql`
-  query($name: String!, $relDir: String!) {
+  query($name: String!, $relDir: String!, $inUseExamples: [String!]!) {
     json: file(fields: { name: { eq: $name } }) {
       childJson {
         name
@@ -169,6 +188,24 @@ export const query = graphql`
           category
           subcategory
           name
+        }
+      }
+    }
+    inUseImages: allFile(
+      filter: {
+        name: { in: $inUseExamples }
+        sourceInstanceName: { eq: "examples" }
+        extension: { regex: "/(jpg)|(jpeg)|(png)|(gif)/" }
+        dir: { regex: "/.*[^data]$/" }
+      }
+    ) {
+      nodes {
+        name
+        relativeDirectory
+        childImageSharp {
+          fluid(maxWidth: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }

--- a/src/templates/reference/function.js
+++ b/src/templates/reference/function.js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import { Link } from 'gatsby';
 import { useIntl } from 'react-intl';
+import classnames from 'classnames';
 
 import Layout from '../../components/Layout';
 import Content from '../../components/ContentWithSidebar';
@@ -10,16 +11,19 @@ import Sidebar from '../../components/Sidebar';
 import Section from '../../components/ReferenceItemSection';
 import License from '../../components/ReferenceLicense';
 import { CodeList, ExampleList } from '../../components/ReferenceItemList';
+import { ExampleItem } from '../../components/ExamplesList';
 
 import { useTree, useHighlight, useWindowSize } from '../../hooks';
 import {
   usePreparedItems,
   usePreparedExamples,
   usePreparedList,
+  useInUseExamples
 } from '../../hooks/reference';
 import { referencePath } from '../../utils/paths';
 
 import grid from '../../styles/grid.module.css';
+import css from '../../styles/templates/examples/example.module.css';
 
 const RefTemplate = ({ data, pageContext, ...props }) => {
   const { name, libraryName } = pageContext;
@@ -41,6 +45,10 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
   const syntax = usePreparedList(entry?.syntax, libraryName);
   const related = usePreparedList(entry?.related, libraryName, true, true);
   const returns = usePreparedList(entry?.returns, libraryName);
+  const inUseExamples = useInUseExamples(
+    pageContext.inUseExamples,
+    data.inUseImages
+  );
 
   return (
     <Layout withSidebar>
@@ -95,6 +103,15 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
                 <CodeList items={related} />
               </Section>
             )}
+            {inUseExamples && (
+              <Section title={intl.formatMessage({ id: 'inUse' })}>
+                <ul className={classnames(css.related, css.inuse)}>
+                  {inUseExamples.slice(0, 6).map((e, key) => (
+                    <ExampleItem node={e} key={`e-${e.name}`} />
+                  ))}
+                </ul>
+              </Section>
+            )}
             <License />
           </Content>
         ) : (
@@ -114,7 +131,12 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
 export default RefTemplate;
 
 export const query = graphql`
-  query($name: String!, $relDir: String!, $locale: String!) {
+  query(
+    $name: String!
+    $relDir: String!
+    $locale: String!
+    $inUseExamples: [String!]!
+  ) {
     json: file(fields: { name: { eq: $name }, lang: { eq: $locale } }) {
       childJson {
         name
@@ -179,6 +201,24 @@ export const query = graphql`
           category
           subcategory
           name
+        }
+      }
+    }
+    inUseImages: allFile(
+      filter: {
+        name: { in: $inUseExamples }
+        sourceInstanceName: { eq: "examples" }
+        extension: { regex: "/(jpg)|(jpeg)|(png)|(gif)/" }
+        dir: { regex: "/.*[^data]$/" }
+      }
+    ) {
+      nodes {
+        name
+        relativeDirectory
+        childImageSharp {
+          fluid(maxWidth: 200) {
+            ...GatsbyImageSharpFluid
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds **In use** examples for references. It changes:

1. `gatsby-node.js` to add examples to reference pages
2. changes templates `class.js`, `function.js`, `field.js` to feature the In use examples
3. adds a hook to `reference.js` to combine the In use example names and images in one data structure