### PR TITLE
Fix front page example images

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,22 +8,9 @@ import {
 } from 'react';
 import hljs from 'highlight.js/lib/core';
 import processing from 'highlight.js/lib/languages/processing';
-import { shuffleArray, getWin } from '../utils';
+import { getWin } from '../utils';
 
 hljs.registerLanguage('processing', processing);
-
-/**
-  Hook to get random items from an array
-  @param {Array} arr Array of items
-  @param {number} num Number of items to select
-**/
-export const useRandomArray = (arr, num) => {
-  return useMemo(() => {
-    const copy = arr.slice();
-    shuffleArray(copy);
-    return num && num < copy.length ? copy.slice(0, num) : copy;
-  }, [arr, num]);
-};
 
 /**
   Performs syntax highlighting on all <pre><code> in the body

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import { graphql } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
@@ -11,7 +11,7 @@ import Button from '../components/Button';
 import Card from '../components/Card';
 import Sketch from '../components/sketch/Sketch';
 
-import { useRandomArray } from '../hooks';
+import { shuffleArray } from '../utils';
 import { usePreparedExamples } from '../hooks/examples';
 
 import css from '../styles/pages/index.module.css';
@@ -20,12 +20,18 @@ import grid from '../styles/grid.module.css';
 const IndexPage = ({ data }) => {
   const intl = useIntl();
   const { locale } = useLocalization();
-
   const featuredExamples = usePreparedExamples(
     data.examples.nodes,
     data.exampleImages.nodes
   );
-  const randomExamples = useRandomArray(featuredExamples, 4);
+
+  // We only show the randomized example once the site is rendered on the
+  // client since otherwise the images will always be the ones picked by SSR
+  const [randomExamples, setRandomExamples] = useState([]);
+  useEffect(() => {
+    const shuffled = shuffleArray(featuredExamples.slice());
+    setRandomExamples(shuffled.length > 4 ? shuffled.slice(0, 4) : shuffled);
+  }, [featuredExamples]);
 
   return (
     <Layout mainClassName={css.main}>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,6 +8,7 @@ export const shuffleArray = (array) => {
     const j = Math.floor(Math.random() * (i + 1));
     [array[i], array[j]] = [array[j], array[i]];
   }
+  return array;
 };
 
 export const map = (n, start1, stop1, start2, stop2) => {


### PR DESCRIPTION
This PR fixes #145 so the proper images are shown on the front page. This was a clash between the server-rendered and the client-rendered images since they were relying on `Math.random`, but that random function would only run when the static HTML was being rendered. The solution was to move the randomness to the client in by putting it inside a `useEffect`.