### PR TITLE
Apply no-ligatures rule to both code and pre

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -92,6 +92,7 @@ code,
 pre {
   font-family: var(--font-mono);
   font-size: var(--text-small);
+  font-variant-ligatures: no-common-ligatures;
 }
 
 pre {
@@ -102,7 +103,6 @@ pre {
 
 code {
   margin-bottom: 2px;
-  font-variant-ligatures: no-common-ligatures;
 }
 
 p {


### PR DESCRIPTION
It was being applied to all `code` tags but not to `pre` tag. code highlighting uses `pre` and not `code`, and that was causing the issue

fixes #158 