### PR TITLE
Fix reference translations

### DIFF
--- a/content/references/translations/de/processing/bezier_.de.json
+++ b/content/references/translations/de/processing/bezier_.de.json
@@ -1,6 +1,6 @@
 {
   "examples": "",
-  "related": ["bezierVertex_.html", "curve_.html"],
+  "related": ["bezierVertex_", "curve_"],
   "usage": "",
   "name": "bezier()",
   "description": " DEeee ( begin auto-generated from bezier.xml )\n\n Draws a Bezier curve on the screen. These curves are defined by a series\n of anchor and control points. The first two parameters specify the first\n anchor point and the last two parameters specify the other anchor point.\n The middle parameters specify the control points which define the shape\n of the curve. Bezier curves were developed by French engineer Pierre\n Bezier. Using the 3D version requires rendering with P3D (see the\n Environment reference for more information).\n\n ( end auto-generated )\n\n ",

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -154,7 +154,7 @@ async function createReference(actions, graphql) {
         path: refPath,
         component: refTemplate,
         context: {
-          name: refPage.node.name,
+          name,
           relDir,
           libraryName,
           inUseExamples: inUseExamples

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -6,7 +6,7 @@ import { titleCase } from '../utils';
 
 import css from './Breadcrumbs.module.css';
 
-export const Breadcrumbs = ({ className, trail, locale }) => {
+export const Breadcrumbs = ({ className, trail }) => {
   if (!trail || trail.length === 0) {
     return null;
   }
@@ -19,9 +19,7 @@ export const Breadcrumbs = ({ className, trail, locale }) => {
             {isString ? (
               item
             ) : (
-              <Link to={item.slug} language={locale}>
-                {titleCase(item.label)}
-              </Link>
+              <Link to={item.slug}>{titleCase(item.label)}</Link>
             )}
             {i < trail.length - 1 && <span className={css.sep}>&#8594;</span>}
           </span>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -167,7 +167,6 @@ const Navbar = ({ siteTitle, scrolled }) => {
                           ) : (
                             <Link
                               to={subitem.href}
-                              language={locale}
                               tabIndex={item.name === showSubmenu ? 0 : -1}>
                               {intl.formatMessage({ id: subitem.name })}
                             </Link>

--- a/src/components/SidebarTreeList.js
+++ b/src/components/SidebarTreeList.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
 import { LocalizedLink as Link } from 'gatsby-theme-i18n';
-import { useLocalization } from 'gatsby-theme-i18n';
 
 import SidebarGroup from './SidebarGroup';
 
@@ -9,7 +8,6 @@ import grid from '../styles/grid.module.css';
 import css from './SidebarTreeList.module.css';
 
 const SidebarTreeList = ({ tree, useSerif }) => {
-  const { locale } = useLocalization();
   return (
     <div className={css.root}>
       {Object.keys(tree).map((category) => (
@@ -27,8 +25,7 @@ const SidebarTreeList = ({ tree, useSerif }) => {
                         className={classnames(grid.col1andhalf, {
                           [css.serif]: useSerif
                         })}
-                        to={item.path}
-                        language={locale}>
+                        to={item.path}>
                         {item.name}
                       </Link>
                     </li>

--- a/src/components/examples/ExamplesList.js
+++ b/src/components/examples/ExamplesList.js
@@ -1,6 +1,6 @@
 import React, { Fragment, memo, useState } from 'react';
 import classnames from 'classnames';
-import { LocalizedLink as Link, useLocalization } from 'gatsby-theme-i18n';
+import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import { useIntl } from 'react-intl';
 import Img from 'gatsby-image';
 
@@ -13,7 +13,6 @@ import css from './ExamplesList.module.css';
 import grid from '../../styles/grid.module.css';
 
 const ExamplesList = ({ tree }) => {
-  const { locale } = useLocalization();
   const intl = useIntl();
   const [curated, setCurated] = useState(false);
 
@@ -54,11 +53,7 @@ const ExamplesList = ({ tree }) => {
                 </h3>
                 <ul className={classnames(grid.col, grid.grid, css.examples)}>
                   {sortedTree[category][subcategory].map((item, key) => (
-                    <ExampleItem
-                      node={item}
-                      locale={locale}
-                      key={`item-${item.name}`}
-                    />
+                    <ExampleItem node={item} key={`item-${item.name}`} />
                   ))}
                 </ul>
               </Fragment>
@@ -70,10 +65,10 @@ const ExamplesList = ({ tree }) => {
   );
 };
 
-export const ExampleItem = memo(({ node, locale, variant }) => {
+export const ExampleItem = memo(({ node, variant }) => {
   return (
     <li className={classnames(grid.col, css.item, { [css[variant]]: variant })}>
-      <Link to={node.path} language={locale}>
+      <Link to={node.path}>
         {node.image && (
           <Img className={css.cover} fluid={node.image.childImageSharp.fluid} />
         )}

--- a/src/components/reference/ContentList.js
+++ b/src/components/reference/ContentList.js
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { Link } from 'gatsby';
+import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import Img from 'gatsby-image';
 import classnames from 'classnames';
 import { widont } from '../../utils/index.js';

--- a/src/hooks/libraries.js
+++ b/src/hooks/libraries.js
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 /**
   Hook to merge the current language libraries JSON files with the english
   This only happens if the language has the library, otherwise it's hidden.
-  We might want to changes this.
+  We might want to change this.
   @param {Array} english Array of libraries for english
   @param {Array} currentLang Array of libraries for current language
 **/

--- a/src/hooks/tutorials.js
+++ b/src/hooks/tutorials.js
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { sortArray } from '../utils';
 
 /**
   Hook to prepare the video and text examples

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
 import classnames from 'classnames';
-import { LocalizedLink as Link, useLocalization } from 'gatsby-theme-i18n';
+import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import Img from 'gatsby-image';
 
 import Layout from '../components/Layout';
@@ -19,7 +19,6 @@ import grid from '../styles/grid.module.css';
 
 const IndexPage = ({ data }) => {
   const intl = useIntl();
-  const { locale } = useLocalization();
   const featuredExamples = usePreparedExamples(
     data.examples.nodes,
     data.exampleImages.nodes
@@ -70,7 +69,6 @@ const IndexPage = ({ data }) => {
       <Examples
         examples={randomExamples}
         heading={intl.formatMessage({ id: 'examples' })}
-        locale={locale}
       />
       <div className={css.gettingStarted}>
         <div
@@ -278,13 +276,13 @@ const IndexPage = ({ data }) => {
   );
 };
 
-const Examples = memo(({ heading, examples, locale }) => {
+const Examples = memo(({ heading, examples }) => {
   return (
     <div className={classnames(grid.grid, css.examples)}>
       <h3 className={classnames(grid.col, css.examplesHeading)}>{heading}</h3>
       {examples.map((example, i) => (
         <div className={classnames(grid.col, css.example)} key={example.path}>
-          <Link to={example.path} language={locale}>
+          <Link to={example.path}>
             <div className={css.imgContainer}>
               {example.image && (
                 <Img

--- a/src/pages/libraries.js
+++ b/src/pages/libraries.js
@@ -45,7 +45,7 @@ const Libraries = ({ data }) => {
           <h1>{intl.formatMessage({ id: 'libraries' })}</h1>
           <h3>{intl.formatMessage({ id: 'librariesIntro' })}</h3>
         </div>
-        <CoreList libraries={coreLibraries} locale={locale} intl={intl} />
+        <CoreList libraries={coreLibraries} intl={intl} />
         <div className={classnames(grid.col, css.text, css.pushDown)}>
           <h1>{intl.formatMessage({ id: 'contributions' })}</h1>
           <h3>{intl.formatMessage({ id: 'contributionsIntro' })}</h3>
@@ -66,7 +66,7 @@ const Libraries = ({ data }) => {
   );
 };
 
-const CoreList = memo(({ libraries, locale, intl }) => {
+const CoreList = memo(({ libraries, intl }) => {
   return (
     <>
       <h2 className={classnames(grid.col, css.category)} id="core">
@@ -77,9 +77,7 @@ const CoreList = memo(({ libraries, locale, intl }) => {
           return (
             <li key={key} className={classnames(grid.grid, css.item)}>
               <div className={classnames(grid.col, css.itemName)}>
-                <Link
-                  to={referencePath('index', node.frontmatter.name)}
-                  language={locale}>
+                <Link to={referencePath('index', node.frontmatter.name)}>
                   <h3>{node.frontmatter.title}</h3>
                 </Link>
               </div>

--- a/src/pages/tutorials.js
+++ b/src/pages/tutorials.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import Img from 'gatsby-image';
-import { useLocalization, LocalizedLink as Link } from 'gatsby-theme-i18n';
+import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import { useIntl } from 'react-intl';
 import classnames from 'classnames';
 
@@ -14,9 +14,7 @@ import css from '../styles/pages/tutorials.module.css';
 import grid from '../styles/grid.module.css';
 
 const Tutorials = ({ data }) => {
-  const { locale } = useLocalization();
   const intl = useIntl();
-
   const videos = usePreparedTutorials(data.video.nodes);
   const texts = usePreparedTutorials(data.text.nodes);
 
@@ -35,11 +33,7 @@ const Tutorials = ({ data }) => {
           {videos.map((tutorial, k) => {
             return (
               <li key={k} className={classnames(grid.col, css.card)}>
-                <a
-                  href={tutorial.link}
-                  target="_blank"
-                  rel="noreferrer"
-                  language={locale}>
+                <a href={tutorial.link} target="_blank" rel="noreferrer">
                   {tutorial.image && (
                     <div className={css.cover}>
                       <Img
@@ -70,7 +64,7 @@ const Tutorials = ({ data }) => {
           {texts.map((tutorial, k) => {
             return (
               <li key={k} className={classnames(grid.col, css.card)}>
-                <Link to={tutorial.slug} language={locale}>
+                <Link to={tutorial.slug}>
                   {tutorial.image && (
                     <div className={css.cover}>
                       <Img

--- a/src/templates/examples/example.js
+++ b/src/templates/examples/example.js
@@ -1,7 +1,7 @@
 import React, { memo, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
-import { LocalizedLink as Link, useLocalization } from 'gatsby-theme-i18n';
+import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
 import Img from 'gatsby-image';
@@ -35,7 +35,6 @@ if (typeof window !== 'undefined') {
 
 const ExampleTemplate = ({ data, pageContext }) => {
   const [showSidebar, setShowSidebar] = useSidebar();
-  const { locale } = useLocalization();
   const intl = useIntl();
 
   const { name, related } = pageContext;
@@ -88,7 +87,7 @@ const ExampleTemplate = ({ data, pageContext }) => {
         />
         {example ? (
           <Content collapsed={!showSidebar}>
-            <Breadcrumbs locale={locale} trail={trail} />
+            <Breadcrumbs trail={trail} />
             <h1>{example.title}</h1>
             {example.author && (
               <h3>
@@ -118,7 +117,6 @@ const ExampleTemplate = ({ data, pageContext }) => {
             <RelatedExamples
               examples={relatedExamples}
               heading={intl.formatMessage({ id: 'relatedExamples' })}
-              locale={locale}
             />
             <p className={classnames(css.note)}>
               {intl.formatMessage({ id: 'exampleInfo' })}
@@ -162,7 +160,7 @@ const FeaturedFunctions = memo(({ heading, featured }) => {
   );
 });
 
-const RelatedExamples = memo(({ heading, examples, locale }) => {
+const RelatedExamples = memo(({ heading, examples }) => {
   return (
     <div>
       <h3>{heading}</h3>
@@ -170,7 +168,6 @@ const RelatedExamples = memo(({ heading, examples, locale }) => {
         {examples.slice(0, 6).map((example, key) => (
           <ExampleItem
             node={example}
-            locale={locale}
             key={`example-${example.name}`}
             variant="related"
           />

--- a/src/templates/reference/class.js
+++ b/src/templates/reference/class.js
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import { Link } from 'gatsby';
 import { useIntl } from 'react-intl';
-import { useLocalization } from 'gatsby-theme-i18n';
 import { widont } from '../../utils/index.js';
 
 import Layout from '../../components/Layout';
@@ -32,7 +31,6 @@ const ClassRefTemplate = ({ data, pageContext }) => {
   const entry = data?.json?.childJson;
   const isProcessing = libraryName === 'processing';
   const [showSidebar, setShowSidebar] = useSidebar();
-  const { locale } = useLocalization();
   const intl = useIntl();
   useHighlight();
 
@@ -68,7 +66,7 @@ const ClassRefTemplate = ({ data, pageContext }) => {
         />
         {entry ? (
           <Content collapsed={!showSidebar}>
-            <Breadcrumbs locale={locale} trail={trail} />
+            <Breadcrumbs trail={trail} />
             <Section title={intl.formatMessage({ id: 'className' })}>
               <h3>{entry.name}</h3>
             </Section>

--- a/src/templates/reference/field.js
+++ b/src/templates/reference/field.js
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import { Link } from 'gatsby';
 import { useIntl } from 'react-intl';
-import { useLocalization } from 'gatsby-theme-i18n';
 
 import Layout from '../../components/Layout';
 import Content from '../../components/ContentWithSidebar';
@@ -33,7 +32,6 @@ const FieldRefTemplate = ({ data, pageContext }) => {
   const isProcessing = libraryName === 'processing';
 
   const [showSidebar, setShowSidebar] = useSidebar();
-  const { locale } = useLocalization();
   const intl = useIntl();
   useHighlight();
 
@@ -76,7 +74,7 @@ const FieldRefTemplate = ({ data, pageContext }) => {
         />
         {entry ? (
           <Content collapsed={!showSidebar}>
-            <Breadcrumbs locale={locale} trail={trail} />
+            <Breadcrumbs trail={trail} />
             <Section title={intl.formatMessage({ id: 'name' })}>
               <h3>{entry.name}</h3>
             </Section>

--- a/src/templates/reference/function.js
+++ b/src/templates/reference/function.js
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import { Link } from 'gatsby';
 import { useIntl } from 'react-intl';
-import { useLocalization } from 'gatsby-theme-i18n';
 
 import Layout from '../../components/Layout';
 import Content from '../../components/ContentWithSidebar';
@@ -33,7 +32,6 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
   const [showSidebar, setShowSidebar] = useSidebar();
 
   const intl = useIntl();
-  const { locale } = useLocalization();
   useHighlight();
 
   const items = usePreparedItems(data.items.nodes, libraryName);
@@ -77,7 +75,7 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
         />
         {entry ? (
           <Content collapsed={!showSidebar}>
-            <Breadcrumbs locale={locale} trail={trail} />
+            <Breadcrumbs trail={trail} />
             <Section short title={intl.formatMessage({ id: 'name' })}>
               <h3>{entry.name}</h3>
             </Section>

--- a/src/templates/tutorials/tutorial.js
+++ b/src/templates/tutorials/tutorial.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { graphql, Link } from 'gatsby';
-import { useLocalization } from 'gatsby-theme-i18n';
 import { useIntl } from 'react-intl';
 import classnames from 'classnames';
 
@@ -23,7 +22,6 @@ const TutorialTemplate = ({ data, pageContext }) => {
   const [showSidebar, setShowSidebar] = useSidebar(
     !!mdx?.tableOfContents?.items ? undefined : true
   );
-  const { locale } = useLocalization();
   const intl = useIntl();
   useHighlight();
 
@@ -47,7 +45,7 @@ const TutorialTemplate = ({ data, pageContext }) => {
         )}
         {mdx !== null ? (
           <Content collapsed={!showSidebar}>
-            <Breadcrumbs locale={locale} trail={trail} />
+            <Breadcrumbs trail={trail} />
             <h1>{mdx.frontmatter.title}</h1>
             <p className={css.author}>{`${intl.formatMessage({ id: 'by' })} ${
               mdx.frontmatter.author


### PR DESCRIPTION
This PR fixes the translation system for the reference and removes the `useLocalization` hook from most pages since the `LocalizedLink` component automatically links to the current `locale`.