### PR TITLE
Better titles for translations

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -146,6 +146,13 @@ async function createReference(actions, graphql) {
       })
       .map((e) => e.node.name);
 
+    const context = {
+      name,
+      relDir,
+      libraryName,
+      inUseExamples: inUseExamples
+    };
+
     if (
       refPage.node.childJson.type === 'function' ||
       refPage.node.childJson.type === 'method'
@@ -153,23 +160,13 @@ async function createReference(actions, graphql) {
       createPage({
         path: refPath,
         component: refTemplate,
-        context: {
-          name,
-          relDir,
-          libraryName,
-          inUseExamples: inUseExamples
-        }
+        context
       });
     } else if (refPage.node.childJson.type === 'class') {
       createPage({
         path: refPath,
         component: classRefTemplate,
-        context: {
-          name: refPage.node.name,
-          relDir,
-          libraryName,
-          inUseExamples: inUseExamples
-        }
+        context
       });
     } else if (
       refPage.node.childJson.type === 'field' ||
@@ -178,12 +175,7 @@ async function createReference(actions, graphql) {
       createPage({
         path: refPath,
         component: fieldRefTemplate,
-        context: {
-          name: refPage.node.name,
-          relDir,
-          libraryName,
-          inUseExamples: inUseExamples
-        }
+        context
       });
     }
   });

--- a/src/templates/reference/class.js
+++ b/src/templates/reference/class.js
@@ -54,7 +54,11 @@ const ClassRefTemplate = ({ data, pageContext }) => {
     <Layout withSidebar withBreadcrumbs>
       <Helmet>
         <title>
-          {name} / {isProcessing ? 'Reference' : 'Libraries'}
+          {data.en.childJson.name}
+          {' / '}
+          {isProcessing
+            ? intl.formatMessage({ id: 'reference' })
+            : intl.formatMessage({ id: 'libraries' })}
         </title>
       </Helmet>
       <div className={grid.grid}>
@@ -171,6 +175,14 @@ export const query = graphql`
           name
           description
         }
+      }
+    }
+    en: file(
+      fields: { name: { eq: $name }, lang: { eq: "en" } }
+      sourceInstanceName: { eq: "json" }
+    ) {
+      childJson {
+        name
       }
     }
     images: allFile(

--- a/src/templates/reference/field.js
+++ b/src/templates/reference/field.js
@@ -54,15 +54,18 @@ const FieldRefTemplate = ({ data, pageContext }) => {
     entry?.classanchor
   );
 
-  const title = entry?.classanchor
-    ? `${entry.classanchor}::${entry.name}`
-    : name;
+  const title = data.en.childJson.classanchor
+    ? `${data.en.childJson.classanchor}::${data.en.childJson.name}`
+    : data.en.childJson.name;
 
   return (
     <Layout withSidebar withBreadcrumbs>
       <Helmet>
         <title>
-          {title} / {isProcessing ? 'Reference' : 'Libraries'}
+          {title} /
+          {isProcessing
+            ? intl.formatMessage({ id: 'reference' })
+            : intl.formatMessage({ id: 'libraries' })}
         </title>
       </Helmet>
       <div className={grid.grid}>
@@ -140,10 +143,11 @@ export const query = graphql`
   query(
     $name: String!
     $relDir: String!
+    $locale: String!
     $inUseExamples: [String!]!
     $libraryName: String!
   ) {
-    json: file(fields: { name: { eq: $name } }) {
+    json: file(fields: { name: { eq: $name }, lang: { eq: $locale } }) {
       childJson {
         name
         classanchor
@@ -158,6 +162,12 @@ export const query = graphql`
         }
         related
         returns
+      }
+    }
+    en: file(fields: { name: { eq: $name }, lang: { eq: "en" } }) {
+      childJson {
+        name
+        classanchor
       }
     }
     images: allFile(

--- a/src/templates/reference/function.js
+++ b/src/templates/reference/function.js
@@ -61,9 +61,11 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
     <Layout withSidebar withBreadcrumbs>
       <Helmet>
         <title>
-          {entry?.name ?? ''}
+          {data.en.childJson.name}
           {' / '}
-          {isProcessing ? 'Reference' : 'Libraries'}
+          {isProcessing
+            ? intl.formatMessage({ id: 'reference' })
+            : intl.formatMessage({ id: 'libraries' })}
         </title>
       </Helmet>
       <div className={grid.grid}>
@@ -175,6 +177,11 @@ export const query = graphql`
         related
         returns
         classanchor
+      }
+    }
+    en: file(fields: { name: { eq: $name }, lang: { eq: "en" } }) {
+      childJson {
+        name
       }
     }
     images: allFile(


### PR DESCRIPTION
This PR adds better titles for translations by loading the `name` property from the english translation and using in the title. Because the function name is not translated, this makes it possible to have a title that says `bezier() / Reference / Processing` instead of the current ` / Reference / Processing`.