### PR TITLE
Better breadcrumbs for class methods and fields

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -152,11 +152,13 @@ async function createReference(actions, graphql) {
       name,
       relDir,
       libraryName,
-      inUseExamples: inUseExamples
+      inUseExamples: inUseExamples,
+      hasClassanchor: false
     };
 
     // Used to load category and subcategory from class parent for breadcrumbs
     if (type === 'method' || type === 'field') {
+      context.hasClassanchor = true;
       context.classanchor = classanchor;
     }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -87,6 +87,7 @@ async function createReference(actions, graphql) {
               relativeDirectory
               childJson {
                 type
+                classanchor
               }
             }
           }
@@ -133,6 +134,7 @@ async function createReference(actions, graphql) {
     const [lang, libraryName] = refPage.node.relativeDirectory.split('/');
     const refPath = referencePath(name, libraryName, lang);
     const relDir = libraryName + '/' + name;
+    const { type, classanchor } = refPage.node.childJson;
 
     const inUseExamples = inUse.data.allFile.edges
       .filter((n) => {
@@ -153,25 +155,24 @@ async function createReference(actions, graphql) {
       inUseExamples: inUseExamples
     };
 
-    if (
-      refPage.node.childJson.type === 'function' ||
-      refPage.node.childJson.type === 'method'
-    ) {
+    // Used to load category and subcategory from class parent for breadcrumbs
+    if (type === 'method' || type === 'field') {
+      context.classanchor = classanchor;
+    }
+
+    if (type === 'function' || type === 'method') {
       createPage({
         path: refPath,
         component: refTemplate,
         context
       });
-    } else if (refPage.node.childJson.type === 'class') {
+    } else if (type === 'class') {
       createPage({
         path: refPath,
         component: classRefTemplate,
         context
       });
-    } else if (
-      refPage.node.childJson.type === 'field' ||
-      refPage.node.childJson.type === 'other'
-    ) {
+    } else if (type === 'field' || type === 'other') {
       createPage({
         path: refPath,
         component: fieldRefTemplate,

--- a/src/templates/reference/field.js
+++ b/src/templates/reference/field.js
@@ -27,9 +27,11 @@ import { referencePath } from '../../utils/paths';
 import grid from '../../styles/grid.module.css';
 
 const FieldRefTemplate = ({ data, pageContext }) => {
-  const entry = data?.json?.childJson;
   const { name, libraryName } = pageContext;
   const isProcessing = libraryName === 'processing';
+
+  const parent = data?.parent?.childJson;
+  const entry = data?.json?.childJson;
 
   const [showSidebar, setShowSidebar] = useSidebar('reference');
   const intl = useIntl();
@@ -49,8 +51,8 @@ const FieldRefTemplate = ({ data, pageContext }) => {
 
   const trail = useTrail(
     libraryName,
-    entry?.category,
-    entry?.subcategory,
+    parent ? parent.category : entry?.category,
+    parent ? parent.subcategory : entry?.subcategory,
     entry?.classanchor
   );
 
@@ -146,6 +148,7 @@ export const query = graphql`
     $locale: String!
     $inUseExamples: [String!]!
     $libraryName: String!
+    $classanchor: String
   ) {
     json: file(fields: { name: { eq: $name }, lang: { eq: $locale } }) {
       childJson {
@@ -168,6 +171,13 @@ export const query = graphql`
       childJson {
         name
         classanchor
+      }
+    }
+    parent: file(fields: { name: { eq: $classanchor }, lang: { eq: "en" } }) {
+      childJson {
+        name
+        category
+        subcategory
       }
     }
     images: allFile(

--- a/src/templates/reference/field.js
+++ b/src/templates/reference/field.js
@@ -148,6 +148,7 @@ export const query = graphql`
     $locale: String!
     $inUseExamples: [String!]!
     $libraryName: String!
+    $hasClassanchor: Boolean!
     $classanchor: String
   ) {
     json: file(fields: { name: { eq: $name }, lang: { eq: $locale } }) {
@@ -173,7 +174,8 @@ export const query = graphql`
         classanchor
       }
     }
-    parent: file(fields: { name: { eq: $classanchor }, lang: { eq: "en" } }) {
+    parent: file(fields: { name: { eq: $classanchor }, lang: { eq: "en" } })
+      @include(if: $hasClassanchor) {
       childJson {
         name
         category

--- a/src/templates/reference/function.js
+++ b/src/templates/reference/function.js
@@ -34,11 +34,12 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
   const intl = useIntl();
   useHighlight();
 
+  const parent = data?.parent?.childJson;
+  const entry = data?.json?.childJson;
+
   const items = usePreparedItems(data.items.nodes, libraryName);
   const examples = usePreparedExamples(data.pdes.edges, data.images.edges);
   const tree = useTree(items);
-
-  const entry = data?.json?.childJson;
 
   const inUse = usePreparedList(entry?.inUse, libraryName, true, true);
   const parameters = usePreparedList(entry?.parameters, libraryName);
@@ -52,8 +53,8 @@ const RefTemplate = ({ data, pageContext, ...props }) => {
 
   const trail = useTrail(
     libraryName,
-    entry?.category,
-    entry?.subcategory,
+    parent ? parent.category : entry?.category,
+    parent ? parent.subcategory : entry?.subcategory,
     entry?.classanchor
   );
 
@@ -161,6 +162,7 @@ export const query = graphql`
     $locale: String!
     $inUseExamples: [String!]!
     $libraryName: String!
+    $classanchor: String
   ) {
     json: file(fields: { name: { eq: $name }, lang: { eq: $locale } }) {
       childJson {
@@ -182,6 +184,13 @@ export const query = graphql`
     en: file(fields: { name: { eq: $name }, lang: { eq: "en" } }) {
       childJson {
         name
+      }
+    }
+    parent: file(fields: { name: { eq: $classanchor }, lang: { eq: "en" } }) {
+      childJson {
+        name
+        category
+        subcategory
       }
     }
     images: allFile(

--- a/src/templates/reference/function.js
+++ b/src/templates/reference/function.js
@@ -162,6 +162,7 @@ export const query = graphql`
     $locale: String!
     $inUseExamples: [String!]!
     $libraryName: String!
+    $hasClassanchor: Boolean!
     $classanchor: String
   ) {
     json: file(fields: { name: { eq: $name }, lang: { eq: $locale } }) {
@@ -186,7 +187,8 @@ export const query = graphql`
         name
       }
     }
-    parent: file(fields: { name: { eq: $classanchor }, lang: { eq: "en" } }) {
+    parent: file(fields: { name: { eq: $classanchor }, lang: { eq: "en" } })
+      @include(if: $hasClassanchor) {
       childJson {
         name
         category


### PR DESCRIPTION
This introduces a logic in the reference where class methods and fields that their `category` and `subcategory` from their parent class. This is needed because some methods are injected into classes at build time, so we only have a single JavaDoc comment for something like `Pimage.mask()` and `mask()`. 