### PR TITLE
Updating releases to reflect processing.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,3 +20,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/content/download/selected.json
+++ b/content/download/selected.json
@@ -4,9 +4,5 @@
     "processing-0269-3.5.3",
     "processing-0227-2.2.1"
   ],
-  "selectedPreReleases": [
-    "processing-1272-4.0a3",
-    "processing-1271-4.0a2",
-    "processing-1270-4.0a1"
-  ]
+  "selectedPreReleases": ["processing-1275-4.0a6", "processing-1274-4.0a5"]
 }

--- a/docs/download.md
+++ b/docs/download.md
@@ -8,7 +8,7 @@ In order to not require an API token on GitHub in development, there is a separa
 
 1. Make sure that the release has been published on GitHub
 2. Edit the [`selected.json`](/content/download/selected.json) file to include the new release tag
-3. Make a PR to the `master` branch. When this PR is merged, a GitHub action will take care of fetching the release data from GitHub and redeploy the website.
+3. Make a PR to the `master` branch. When this PR is merged and a new GitHub release is created, a GitHub action will take care of fetching the release data from GitHub and redeploy the website.
 
 If you want to see the changes on your local machine before merging the PR, you can run the fetching script like this:
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,md}\"",
     "fetchReleases": "node scripts/fetchReleases.js",
     "deploy": "static deploy",
-    "deployGithub": "gatsby clean && static deploy --env production --confirm",
+    "deployGithub": "gatsby clean && npm run fetchReleases && static deploy --env production --confirm",
     "open": "static open"
   },
   "dependencies": {


### PR DESCRIPTION
This PR updates the `/download` page to reflect the releases on the current processing.org website. It also updates the GitHub action so the releases are fetches automatically whenever a new release is triggered.