### PR TITLE
HTML entities

### DIFF
--- a/content/references/examples/processing/ArrayList/ArrayList_0.pde
+++ b/content/references/examples/processing/ArrayList/ArrayList_0.pde
@@ -1,9 +1,9 @@
 // These are code fragments that show how to use an ArrayList.
 // They won't compile because they assume the existence of a Particle class.
 
-// Declaring the ArrayList, note the use of the syntax "&lt;Particle&gt;" to indicate
+// Declaring the ArrayList, note the use of the syntax "<Particle>" to indicate
 // our intention to fill this ArrayList with Particle objects
-ArrayList&lt;Particle&gt; particles = new ArrayList&lt;Particle&gt;();
+ArrayList<Particle> particles = new ArrayList<Particle>();
 
 // Objects can be added to an ArrayList with add()
 particles.add(new Particle());

--- a/content/references/examples/processing/HashMap/HashMap_0.pde
+++ b/content/references/examples/processing/HashMap/HashMap_0.pde
@@ -1,7 +1,7 @@
 import java.util.Map;
 
 // Note the HashMap's "key" is a String and "value" is an Integer
-HashMap&lt;String,Integer&gt; hm = new HashMap&lt;String,Integer&gt;();
+HashMap<String,Integer> hm = new HashMap<String,Integer>();
 
 // Putting key-value pairs in the HashMap
 hm.put("Ava", 1);

--- a/content/references/examples/processing/XML/XML_0.pde
+++ b/content/references/examples/processing/XML/XML_0.pde
@@ -1,12 +1,12 @@
-// The following short XML file called "mammals.xml" is parsed 
+// The following short XML file called "mammals.xml" is parsed
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_addChild_/XML_addChild_0.pde
+++ b/content/references/examples/processing/XML_addChild_/XML_addChild_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 
@@ -18,9 +18,9 @@ void setup() {
 }
 
 // Sketch prints:
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;animal&gt;bloodhound&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// <animal>bloodhound</animal>
+// </mammals>

--- a/content/references/examples/processing/XML_format_/XML_format_0.pde
+++ b/content/references/examples/processing/XML_format_/XML_format_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 
@@ -28,20 +28,20 @@ void setup() {
 }
 
 // Sketch prints:
-//&lt;mammals&gt;&lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-  &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-  &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;&lt;/mammals&gt;
+//<mammals><animal id="0" species="Capra hircus">Goat</animal>
+  <animal id="1" species="Panthera pardus">Leopard</animal>
+  <animal id="2" species="Equus zebra">Zebra</animal></mammals>
 //
-//&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
-//&lt;mammals&gt;
-//&lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//&lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//&lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-//&lt;/mammals&gt;
+//<?xml version="1.0" encoding="UTF-8"?>
+//<mammals>
+//<animal id="0" species="Capra hircus">Goat</animal>
+//<animal id="1" species="Panthera pardus">Leopard</animal>
+//<animal id="2" species="Equus zebra">Zebra</animal>
+//</mammals>
 //
-//&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
-//&lt;mammals&gt;
-//     &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//     &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//     &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-//&lt;/mammals&gt;
+//<?xml version="1.0" encoding="UTF-8"?>
+//<mammals>
+//     <animal id="0" species="Capra hircus">Goat</animal>
+//     <animal id="1" species="Panthera pardus">Leopard</animal>
+//     <animal id="2" species="Equus zebra">Zebra</animal>
+//</mammals>

--- a/content/references/examples/processing/XML_getAttributeCount_/XML_getAttributeCount_0.pde
+++ b/content/references/examples/processing/XML_getAttributeCount_/XML_getAttributeCount_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getChild_/XML_getChild_0.pde
+++ b/content/references/examples/processing/XML_getChild_/XML_getChild_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getChildren_/XML_getChildren_0.pde
+++ b/content/references/examples/processing/XML_getChildren_/XML_getChildren_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getContent_/XML_getContent_0.pde
+++ b/content/references/examples/processing/XML_getContent_/XML_getContent_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getFloatContent_/XML_getFloatContent_0.pde
+++ b/content/references/examples/processing/XML_getFloatContent_/XML_getFloatContent_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "positions.xml" is parsed
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;positions&gt;
-//   &lt;position id="0"&gt;128.111&lt;/position&gt;
-//   &lt;position id="1"&gt;256.222&lt;/position&gt;
-//   &lt;position id="2"&gt;512.333&lt;/position&gt;
-// &lt;/positions&gt;
+// <?xml version="1.0"?>
+// <positions>
+//   <position id="0">128.111</position>
+//   <position id="1">256.222</position>
+//   <position id="2">512.333</position>
+// </positions>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getFloat_/XML_getFloat_0.pde
+++ b/content/references/examples/processing/XML_getFloat_/XML_getFloat_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getInt_/XML_getInt_0.pde
+++ b/content/references/examples/processing/XML_getInt_/XML_getInt_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getName_/XML_getName_0.pde
+++ b/content/references/examples/processing/XML_getName_/XML_getName_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getParent_/XML_getParent_0.pde
+++ b/content/references/examples/processing/XML_getParent_/XML_getParent_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_getString_/XML_getString_0.pde
+++ b/content/references/examples/processing/XML_getString_/XML_getString_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_hasAttribute_/XML_hasAttribute_0.pde
+++ b/content/references/examples/processing/XML_hasAttribute_/XML_hasAttribute_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_hasChildren_/XML_hasChildren_0.pde
+++ b/content/references/examples/processing/XML_hasChildren_/XML_hasChildren_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_listAttributes_/XML_listAttributes_0.pde
+++ b/content/references/examples/processing/XML_listAttributes_/XML_listAttributes_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_listChildren_/XML_listChildren_0.pde
+++ b/content/references/examples/processing/XML_listChildren_/XML_listChildren_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_removeChild_/XML_removeChild_0.pde
+++ b/content/references/examples/processing/XML_removeChild_/XML_removeChild_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 
@@ -18,8 +18,8 @@ void setup() {
 }
 
 // Sketch prints:
-// &lt;mammals&gt;
+// <mammals>
 //   
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>

--- a/content/references/examples/processing/XML_setContent_/XML_setContent_0.pde
+++ b/content/references/examples/processing/XML_setContent_/XML_setContent_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_setFloat_/XML_setFloat_0.pde
+++ b/content/references/examples/processing/XML_setFloat_/XML_setFloat_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_setInt_/XML_setInt_0.pde
+++ b/content/references/examples/processing/XML_setInt_/XML_setInt_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_setName_/XML_setName_0.pde
+++ b/content/references/examples/processing/XML_setName_/XML_setName_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_setString_/XML_setString_0.pde
+++ b/content/references/examples/processing/XML_setString_/XML_setString_0.pde
@@ -1,12 +1,12 @@
 // The following short XML file called "mammals.xml" is parsed 
 // in the code below. It must be in the project's "data" folder.
 //
-// &lt;?xml version=&quot;1.0&quot;?&gt;
-// &lt;mammals&gt;
-//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
-//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
-//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
-// &lt;/mammals&gt;
+// <?xml version="1.0"?>
+// <mammals>
+//   <animal id="0" species="Capra hircus">Goat</animal>
+//   <animal id="1" species="Panthera pardus">Leopard</animal>
+//   <animal id="2" species="Equus zebra">Zebra</animal>
+// </mammals>
 
 XML xml;
 

--- a/content/references/examples/processing/XML_toString_/XML_toString_0.pde
+++ b/content/references/examples/processing/XML_toString_/XML_toString_0.pde
@@ -1,4 +1,4 @@
-String data = "&lt;mammals&gt;&lt;animal&gt;Goat&lt;/animal&gt;&lt;/mammals&gt;";
+String data = "<mammals><animal>Goat</animal></mammals>";
 
 void setup() {
   XML xml = parseXML(data);
@@ -9,7 +9,7 @@ void setup() {
 }
 
 // Sketch prints:
-//&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
-//&lt;mammals&gt;
-//  &lt;animal&gt;Goat&lt;/animal&gt;
-//&lt;/mammals&gt;
+//<?xml version="1.0" encoding="UTF-8"?>
+//<mammals>
+//  <animal>Goat</animal>
+//</mammals>

--- a/content/references/examples/processing/bitwiseAND/bitwiseAND_0.pde
+++ b/content/references/examples/processing/bitwiseAND/bitwiseAND_0.pde
@@ -1,4 +1,4 @@
 int a = 207;    // In binary: 11001111
 int b = 61;     // In binary: 00111101
-int c = a &amp; b; // In binary: 00001101
+int c = a & b; // In binary: 00001101
 println(c);     // Prints "13", the decimal equivalent to 00001101

--- a/package-lock.json
+++ b/package-lock.json
@@ -11722,9 +11722,9 @@
       }
     },
     "highlight.js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
-      "integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA=="
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
     },
     "himalaya": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gatsby-transformer-json": "^3.9.0",
     "gatsby-transformer-remark": "^4.6.0",
     "gatsby-transformer-sharp": "^3.9.0",
-    "highlight.js": "^11.1.0",
+    "highlight.js": "^11.2.0",
     "lodash": "4.17.21",
     "luxon": "^1.27.0",
     "p5": "^1.4.0",

--- a/src/components/FilterBar.module.css
+++ b/src/components/FilterBar.module.css
@@ -22,7 +22,7 @@
     background-color: var(--lightgray);
     font-size: var(--text-medium);
     color: inherit;
-    font-variant-ligatures: no-common-ligatures;
+    font-variant-ligatures: none;
   }
 
   & input:focus {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -65,7 +65,15 @@ const Layout = ({ children, withSidebar, withBreadcrumbs, mainClassName }) => {
           {children}
         </H2>
       ),
-      img: (props) => <img {...props} alt=""></img>
+      img: (props) => <img {...props} alt=""></img>,
+      // Render escaped characters as code
+      code: ({ children }) => (
+        <code dangerouslySetInnerHTML={{ __html: children }} />
+      ),
+      // Render escaped characters as code
+      inlineCode: ({ children }) => (
+        <code dangerouslySetInnerHTML={{ __html: children }} />
+      )
     }),
     [setCurrentHeading]
   );

--- a/src/components/SidebarTreeList.module.css
+++ b/src/components/SidebarTreeList.module.css
@@ -7,7 +7,7 @@
     font-size: var(--text-small);
     line-height: 1.6rem;
     font-family: var(--font-mono);
-    font-variant-ligatures: no-common-ligatures;
+    font-variant-ligatures: none;
     text-decoration: none;
     color: var(--black);
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,20 +1,18 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
-import hljs from 'highlight.js/lib/core';
 
 import Button from './Button';
 import CopyButton from './CopyButton';
+
+import { useHighlight } from '../hooks';
+import { escapeHtml } from '../utils';
 
 import * as css from './Tabs.module.css';
 
 const Tabs = ({ pdes, className }) => {
   const [active, setActive] = useState(pdes[0].name);
 
-  useEffect(() => {
-    document.querySelectorAll('pre').forEach((block) => {
-      hljs.highlightBlock(block);
-    });
-  }, [active]);
+  useHighlight();
 
   const onClick = (value) => {
     setActive(value);
@@ -27,7 +25,7 @@ const Tabs = ({ pdes, className }) => {
           <li key={key + 'tab'}>
             <Button
               className={classnames(css.tab, {
-                [css.active]: pde.name === active,
+                [css.active]: pde.name === active
               })}
               onClick={() => onClick(pde.name)}
               onKeyDown={() => onClick(pde.name)}>
@@ -36,19 +34,22 @@ const Tabs = ({ pdes, className }) => {
           </li>
         ))}
       </ul>
-      <div className={css.code}>
-        {pdes.map(
-          (pde, key) =>
-            pde.name === active && (
-              <Fragment key={key}>
-                <CopyButton text={pde.internal.content} />
-                <pre className={css.codeBlock} key={`code-${key}`}>
-                  {pde.internal.content}
-                </pre>
-              </Fragment>
-            )
-        )}
-      </div>
+      {pdes.map((pde, key) => (
+        <div
+          className={classnames(css.code, {
+            [css.activeCode]: pde.name === active
+          })}
+          key={key}>
+          <CopyButton text={pde.internal.content} />
+          <pre className={css.codeBlock}>
+            <code
+              dangerouslySetInnerHTML={{
+                __html: escapeHtml(pde.internal.content)
+              }}
+            />
+          </pre>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/Tabs.module.css
+++ b/src/components/Tabs.module.css
@@ -25,6 +25,11 @@
 
 .code {
   position: relative;
+  display: none;
+}
+
+.activeCode {
+  display: block;
 }
 
 .codeBlock {

--- a/src/components/reference/ContentList.js
+++ b/src/components/reference/ContentList.js
@@ -67,7 +67,7 @@ export const ExampleList = memo(({ examples }) => {
             <div className={classnames(grid.col, css.code)}>
               <CopyButton text={example.code} />
               <pre>
-                <code>{example.code}</code>
+                <code dangerouslySetInnerHTML={{ __html: example.code }} />
               </pre>
             </div>
             {example.image && (

--- a/src/components/reference/ContentList.js
+++ b/src/components/reference/ContentList.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import { GatsbyImage } from 'gatsby-plugin-image';
 import classnames from 'classnames';
-import { widont } from '../../utils/index.js';
+import { widont, escapeHtml } from '../../utils';
 
 import CopyButton from './../CopyButton';
 
@@ -67,7 +67,9 @@ export const ExampleList = memo(({ examples }) => {
             <div className={classnames(grid.col, css.code)}>
               <CopyButton text={example.code} />
               <pre>
-                <code dangerouslySetInnerHTML={{ __html: example.code }} />
+                <code
+                  dangerouslySetInnerHTML={{ __html: escapeHtml(example.code) }}
+                />
               </pre>
             </div>
             {example.image && (

--- a/src/components/reference/ContentList.module.css
+++ b/src/components/reference/ContentList.module.css
@@ -37,7 +37,7 @@
   background-color: var(--lightgray);
   padding: 0.1em 0.3em;
   border-radius: 6px;
-  font-variant-ligatures: no-common-ligatures;
+  font-variant-ligatures: none;
 }
 
 .codeList code {

--- a/src/components/reference/ReferenceList.module.css
+++ b/src/components/reference/ReferenceList.module.css
@@ -49,7 +49,7 @@
   flex-basis: calc(100% / 5.5 * 1.5);
   font-family: var(--font-mono);
   font-size: var(--text-regular);
-  font-variant-ligatures: no-common-ligatures;
+  font-variant-ligatures: none;
   text-decoration: none;
   color: var(--processing-blue-dark);
   white-space: nowrap;
@@ -70,7 +70,7 @@
     background-color: var(--lightgray);
     padding: 0.1em 0.3em;
     border-radius: 6px;
-    font-variant-ligatures: no-common-ligatures;
+    font-variant-ligatures: none;
   }
 }
 

--- a/src/components/reference/Section.module.css
+++ b/src/components/reference/Section.module.css
@@ -22,7 +22,7 @@
 
 .content > h3 {
   font-size: var(--text-xlarge);
-  font-variant-ligatures: no-common-ligatures;
+  font-variant-ligatures: none;
   margin: 0;
 }
 
@@ -42,7 +42,7 @@
   background-color: var(--lightgray);
   padding: 0.1em 0.3em;
   border-radius: 6px;
-  font-variant-ligatures: no-common-ligatures;
+  font-variant-ligatures: none;
 }
 
 @media (--reduced) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -14,12 +14,16 @@ hljs.registerLanguage('processing', processing);
 
 /**
   Performs syntax highlighting on all <pre><code> in the body
+  We added a 500ms delay in order for the first render to have been performed.
 **/
 export const useHighlight = () => {
   useEffect(() => {
-    document.body.querySelectorAll('pre code').forEach((block) => {
-      hljs.highlightBlock(block);
-    });
+    const timeout = setTimeout(() => {
+      document.body.querySelectorAll('pre code').forEach((el) => {
+        hljs.highlightElement(el);
+      });
+    }, 500);
+    return () => clearTimeout(timeout);
   }, []);
 };
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -92,7 +92,7 @@ code,
 pre {
   font-family: var(--font-mono);
   font-size: var(--text-small);
-  font-variant-ligatures: no-common-ligatures;
+  font-variant-ligatures: none;
 }
 
 pre {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -19,6 +19,12 @@ export const months = [
 ];
 
 /**
+  Turns < > & into their unicode equivalents
+**/
+export const escapeHtml = (str) =>
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/**
   Turns a slug into a title
   Example: this_is_something => This Is Something
 **/


### PR DESCRIPTION
This PR fixes the rendering of HTML entities such a `<`, `>` and `&` across the website. The following fixes were put in place:

- **`/reference`**. The reference code examples now have the unescaped code in the `.pde` files, and we escape them before rendering them into `<code>` tags. These files are the smaller snippets that live in the website repo and not the files in `processing-examples`.
- **`/examples`**. The example code is now escaped before rendering into the tabbed `<code>` tags. This makes it possible to keep the unescaped code from `processing-examples` when we make the script to copy the `.pde` files over.
- All MDX pages now render the code content as HTML with custom MDX components. MDX files must still write the escaped characters into the files since it otherwise won't be valid HTML, but the escaped files will now render properly.

I also fixed syntax highlighting across the website as well as a few other smaller things.