### PR TITLE
Remove space after comma

### DIFF
--- a/content/books/learn-python-visually/index.mdx
+++ b/content/books/learn-python-visually/index.mdx
@@ -3,7 +3,7 @@ title: "Learn Python Visually: Creative Coding with Processing.py"
 author: "Tristan Bunn"
 details: "No Starch Press. 296 pages. Paperback and eBook."
 published: "2021-04"
-buy: "Order from No Starch Press-https://nostarch.com/Learn-Python-Visually, Order from Amazon-https://www.amazon.com/Learn-Python-Visually-Tristan-Bunn/dp/1718500963"
+buy: "Order from No Starch Press-https://nostarch.com/Learn-Python-Visually,Order from Amazon-https://www.amazon.com/Learn-Python-Visually-Tristan-Bunn/dp/1718500963"
 language: ""
 ---
 


### PR DESCRIPTION
Sorry :worried:

Turns out inserting a space after a comma breaks the links. Hopefully this fixes it.