### PR TITLE
fix book link parsing to account for links with dashes

### DIFF
--- a/src/hooks/books.js
+++ b/src/hooks/books.js
@@ -35,7 +35,8 @@ export const usePreparedBooks = (books, images) => {
 
       if (preparedBook.buy && preparedBook.buy !== '') {
         preparedBook.buyList = preparedBook.buy.split(',').map((ord) => {
-          const [label, link] = ord.split('-');
+           // split on first occurence of "-" as some links contain dashes
+          const [label, link] = ord.split(/-(.+)/);
           return { label, link };
         });
       }


### PR DESCRIPTION
This fixes broken links on the books pages due to splitting on all - characters (some links use those the dash character as well, not just the link/label delimiter).