### PR TITLE
Disable core prefetching

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,1 @@
+exports.disableCorePrefetching = () => true;


### PR DESCRIPTION
This PR disables the core prefetching mechanism in Gatsby, which should result in far fewer requests.