### PR TITLE
Minimize bundle size and further reduce HTTP requests

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,8 +9,8 @@ module.exports = {
     siteUrl: `https://processing.org/`
   },
   plugins: [
-    `gatsby-plugin-perf-budgets`,
-    `gatsby-plugin-webpack-bundle-analyser-v2`,
+    // `gatsby-plugin-perf-budgets`,
+    // `gatsby-plugin-webpack-bundle-analyser-v2`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-theme-i18n`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,6 +12,8 @@ module.exports = {
     siteUrl: `https://processing.org/`
   },
   plugins: [
+    `gatsby-plugin-perf-budgets`,
+    `gatsby-plugin-webpack-bundle-analyser-v2`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-theme-i18n`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,9 +6,6 @@ const path = require('path');
 
 module.exports = {
   siteMetadata: {
-    title: `Processing`,
-    description: `Welcome to the Processing website`,
-    author: `@processing`,
     siteUrl: `https://processing.org/`
   },
   plugins: [

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,20 @@
+/**
+  Disable inline CSS. This brings the size of the reference from 100MB to 30MB,
+  just by removing inline CSS which already exists in stand-alone CSS files and
+  is only used to speed up initial rendering.
+**/
+export const onPreRenderHTML = ({ getHeadComponents }) => {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+  getHeadComponents().forEach((el) => {
+    if (el.type === 'style' && el.props['data-href']) {
+      el.type = 'link';
+      el.props['href'] = el.props['data-href'];
+      el.props['rel'] = 'stylesheet';
+      el.props['type'] = 'text/css';
+      delete el.props['data-href'];
+      delete el.props['dangerouslySetInnerHTML'];
+    }
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2476,6 +2476,12 @@
         }
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+      "dev": true
+    },
     "@sideway/address": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
@@ -3159,6 +3165,12 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "address": {
       "version": "1.1.2",
@@ -3994,6 +4006,18 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/better-queue-memory/-/better-queue-memory-1.0.4.tgz",
       "integrity": "sha512-SWg5wFIShYffEmJpI6LgbL8/3Dqhku7xI1oEiy6FroP9DbcZlG0ZDjxvPdP9t7hTGW40IpIcC6zVoGT1oxjOuA=="
+    },
+    "bfj": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
+      "integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "check-types": "^8.0.3",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      }
     },
     "big.js": {
       "version": "5.2.2",
@@ -4838,6 +4862,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "check-types": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
+      "integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
+      "dev": true
     },
     "cheerio": {
       "version": "0.22.0",
@@ -6769,6 +6799,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ejs": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.771",
@@ -9515,6 +9551,57 @@
         "lodash": "^4.17.21"
       }
     },
+    "gatsby-plugin-perf-budgets": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-perf-budgets/-/gatsby-plugin-perf-budgets-0.0.18.tgz",
+      "integrity": "sha512-snFFayhHtj6OeMBePnxvdOG1V38MkHS1H4wQ56shAWXmfqWiNE3OrWTUxBS3bC7xy7bpa+af9f6Rwtcp1P1r+Q==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1",
+        "bfj": "^6.1.1",
+        "buffer": "^5.5.0",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "filesize": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+          "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-postcss": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-postcss/-/gatsby-plugin-postcss-4.9.0.tgz",
@@ -9923,6 +10010,27 @@
       "integrity": "sha512-jBx4GRGfsVw57wrqLZ5AkgMHFxcXfFCdwFOC11bDvM9Ls5LokNu2UYNXU0bCbl8agLPYZwEHYwZgaCgk3iQYGQ==",
       "requires": {
         "joi": "^17.2.1"
+      }
+    },
+    "gatsby-plugin-webpack-bundle-analyser-v2": {
+      "version": "1.1.25",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-webpack-bundle-analyser-v2/-/gatsby-plugin-webpack-bundle-analyser-v2-1.1.25.tgz",
+      "integrity": "sha512-o2t2/J1O9MuiDH/WZ1BxTLlqncIx6yFNFffHIPwtITw9ri3AdxxfARe77wLrcwN3mc3gT6LILpYgXNo2pUkHdw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.15.3",
+        "webpack-bundle-analyzer": "^4.4.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "gatsby-react-router-scroll": {
@@ -12021,6 +12129,12 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -15286,6 +15400,12 @@
         "is-wsl": "^2.1.1"
       }
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "opentracing": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.5.tgz",
@@ -18502,6 +18622,17 @@
         "detect-newline": "^1.0.3"
       }
     },
+    "sirv": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.17.tgz",
+      "integrity": "sha512-qx9go5yraB7ekT7bCMqUHJ5jEaOC/GXBxUWv+jeWnb7WzHUFdcQPGWk7YmAwFBaQBrogpuSqd/azbC2lZRqqmw==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -19850,6 +19981,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true
+    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -19887,6 +20024,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
       "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
+    },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
     },
     "ts-node": {
       "version": "9.1.1",
@@ -20684,6 +20827,89 @@
           "requires": {
             "source-list-map": "^2.0.1",
             "source-map": "^0.6.1"
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+      "integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "gzip-size": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+          "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "highlight.js": "^11.2.0",
     "lodash": "4.17.21",
     "luxon": "^1.27.0",
-    "p5": "^1.4.0",
     "postcss": "^8.3.5",
     "postcss-calc": "^8.0.0",
     "postcss-custom-media": "^8.0.0",
@@ -85,6 +84,8 @@
     "@designsystemsinternational/static": "^3.3.12",
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
+    "gatsby-plugin-perf-budgets": "0.0.18",
+    "gatsby-plugin-webpack-bundle-analyser-v2": "^1.1.25",
     "inquirer": "^8.1.2",
     "prettier": "2.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "gatsby-transformer-sharp": "^3.9.0",
     "highlight.js": "^11.2.0",
     "lodash": "4.17.21",
-    "luxon": "^1.27.0",
     "postcss": "^8.3.5",
     "postcss-calc": "^8.0.0",
     "postcss-custom-media": "^8.0.0",

--- a/src/components/HeadMatter.js
+++ b/src/components/HeadMatter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useStaticQuery, graphql } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import { useLocation } from '@reach/router';
 import { truncate } from '../utils';
@@ -11,16 +10,6 @@ export const HeadMatter = ({
   twitterType,
   ogType
 }) => {
-  const data = useStaticQuery(graphql`
-    query HeaderQuery {
-      site {
-        siteMetadata {
-          siteUrl
-        }
-      }
-    }
-  `);
-
   const location = useLocation();
   const shortDescription = truncate(
     description ? description.replace(/\s+/g, ' ') : '',
@@ -30,12 +19,10 @@ export const HeadMatter = ({
   let imgUrl;
   if (img) {
     const imgSrc = img.images.fallback.src;
-    imgUrl = /^http/.test(imgSrc)
-      ? imgSrc
-      : data.site.siteMetadata.siteUrl + imgSrc;
+    imgUrl = /^http/.test(imgSrc) ? imgSrc : 'https://processing.org/' + imgSrc;
   }
 
-  const pageUrl = data.site.siteMetadata.siteUrl + location.pathname;
+  const pageUrl = 'https://processing.org/' + location.pathname;
   return (
     <Helmet>
       <title>{title}</title>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import { useStaticQuery, graphql } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import classnames from 'classnames';
 
@@ -25,16 +24,6 @@ export const LayoutContext = React.createContext();
 const Layout = ({ children, withSidebar, withBreadcrumbs, mainClassName }) => {
   const [headerScrolled, setHeaderScrolled] = useState(false);
   const [currentHeading, setCurrentHeading] = useState('');
-
-  const data = useStaticQuery(graphql`
-    query SiteTitleQuery {
-      site {
-        siteMetadata {
-          title
-        }
-      }
-    }
-  `);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -82,20 +71,14 @@ const Layout = ({ children, withSidebar, withBreadcrumbs, mainClassName }) => {
     <div className={css.root}>
       <LayoutContext.Provider value={{ headerScrolled, currentHeading }}>
         <Helmet titleTemplate="%s / Processing.org" />
-        <Header
-          siteTitle={data.site.siteMetadata.title}
-          scrolled={headerScrolled}
-        />
+        <Header siteTitle="Processing" scrolled={headerScrolled} />
         <main
           className={classnames(css.main, mainClassName, {
             [css.withBreadcrumbs]: withBreadcrumbs
           })}>
           <MDXProvider components={shortcodes}>{children}</MDXProvider>
         </main>
-        <Footer
-          siteTitle={data.site.siteMetadata.title}
-          withSidebar={withSidebar}
-        />
+        <Footer siteTitle="Processing" withSidebar={withSidebar} />
       </LayoutContext.Provider>
     </div>
   );

--- a/src/hooks/download.js
+++ b/src/hooks/download.js
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { DateTime } from 'luxon';
 
 const getOS = (name) => {
   if (name.includes('windows') || name.includes('.exe')) return 'Windows';
@@ -32,9 +31,11 @@ export const usePreparedReleases = (releases) => {
       const item = {
         name: release.name,
         version: release.name.replace('Processing', '').trim(),
-        publishedAt: DateTime.fromISO(release.publishedAt).toLocaleString(
-          DateTime.DATE_FULL
-        ),
+        publishedAt: new Date(release.publishedAt).toLocaleString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
+        }),
         assets: []
       };
 

--- a/src/templates/examples/example.js
+++ b/src/templates/examples/example.js
@@ -5,7 +5,6 @@ import { LocalizedLink as Link } from 'gatsby-theme-i18n';
 import classnames from 'classnames';
 import { useIntl } from 'react-intl';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
-import p5 from 'p5';
 
 import HeadMatter from '../../components/HeadMatter';
 import Layout from '../../components/Layout';
@@ -27,12 +26,6 @@ import {
 
 import * as css from '../../styles/templates/examples/example.module.css';
 import * as grid from '../../styles/grid.module.css';
-
-// This is to make sure that p5.Vector and other namespaced classes
-// work in the live sketch examples.
-if (typeof window !== 'undefined') {
-  window.p5 = p5;
-}
 
 const ExampleTemplate = ({ data, pageContext }) => {
   const [showSidebar, setShowSidebar] = useSidebar('examples');
@@ -56,7 +49,7 @@ const ExampleTemplate = ({ data, pageContext }) => {
       const tryToRunSketch = () => {
         if (window.runLiveSketch) {
           console.log('Live sketch: running');
-          p5Instance = new p5(window.runLiveSketch, 'example-cover');
+          p5Instance = new window.p5(window.runLiveSketch, 'example-cover');
         } else {
           console.log('Live sketch: Not ready');
           setTimeout(tryToRunSketch, 50);
@@ -80,6 +73,9 @@ const ExampleTemplate = ({ data, pageContext }) => {
         img={getImage(image)}
       />
       <Helmet>
+        <script
+          src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.min.js"
+          crossorigin="anonymous"></script>
         {liveSketch && <script>{`${liveSketch.childRawCode.content}`}</script>}
       </Helmet>
       <div className={grid.grid}>


### PR DESCRIPTION
This PR does two things:

## Minize bundle size

- **Remove inline CSS** It minimizes the bundle size by removing the inline CSS on all pages, relying only on the external CSS files. In theory, this makes the site a bit slower to render, but it really doesn't seem like a problem from my tests. The change results in the `/reference` folder going from 100MB to 30MB in uncompressed size 👀 . 
- **Remove p5 as dependency**. The p5.js library is 1.8MB in uncompressed size, which made it the by far largest JS to load on the website. This PR removes the `p5` import in favor of using CDNJS. We need to revisit this for the offline version since the interactive examples won't work without an internet connection, but it will make a big difference with Cloudfront since it's the 3rd most loaded JS file in terms of size.
- **Remove `luxon`as dependency**. We were relying on `luxon` and its 300kb for a single line of code. This removes the lib to rely on `toLocaleString` instead.

## Further reduce HTTP requests

- Adding to the work already done, this PR reduces the number of HTTP requests by minimizing the use of `useStatucQuery` in two main components: `HeadMatter` and `Layout`.