### PR TITLE
Input font size of search-bar

### DIFF
--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -10,6 +10,7 @@
   border-radius: 40px;
   margin-left: auto;
   width: 100%;
+  font-size: 1.3rem;
   padding: 4px 10px 2px 12px;
   height: 100%;
   outline: none;


### PR DESCRIPTION
#288 

Fixed the font size of input search bar text, all letters are completely visible.

Before:
![size-wrong](https://user-images.githubusercontent.com/77936051/149655915-d7751245-b31c-46f7-a344-a130b731be10.JPG)

After:
![size-fixed](https://user-images.githubusercontent.com/77936051/149655919-e8cbf7cc-3faf-41fa-a85f-97f938346cff.JPG)

