### PR TITLE
Removing gatsby-remark-images-anywhere.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -103,27 +103,12 @@ module.exports = {
         ],
         gatsbyRemarkPlugins: [
           {
-            resolve: `gatsby-remark-images-anywhere`,
+            resolve: `gatsby-remark-images`,
             options: {
-              createMarkup: ({
-                src,
-                srcSet,
-                sizes,
-                aspectRatio,
-                alt,
-                base64,
-                presentationWidth
-              }) =>
-                `<picture style="position: relative; overflow: hidden; display: inline-block; padding-bottom: ${
-                  (1 / aspectRatio) * 100
-                }%; width: 100%; height: 0;"><source src="${src}" srcSet="${srcSet}" /><img src="${src}" srcSet="${srcSet}" alt="${alt}" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center center;"/></picture>`,
-              maxWidth: 1200,
-              showCaptions: true
+              maxWidth: 1200
             }
           },
-          {
-            resolve: `gatsby-remark-copy-linked-files`
-          }
+          `gatsby-remark-copy-linked-files`
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "gatsby-plugin-sharp": "3.9.0",
     "gatsby-remark-copy-linked-files": "^4.6.0",
     "gatsby-remark-images": "^5.6.0",
-    "gatsby-remark-images-anywhere": "^1.3.1",
     "gatsby-remark-picture": "^1.0.1",
     "gatsby-remark-static-images": "^1.2.1",
     "gatsby-remark-unwrap-images": "^1.0.2",


### PR DESCRIPTION
This PR removes gatsby-remark-images-anywhere in order to just use gatsby-remark-images as a plugin for loading images in mdx. Solves #291.