### PR TITLE
Fixing pre-releases issue on selected.json

### DIFF
--- a/content/download/selected.json
+++ b/content/download/selected.json
@@ -3,5 +3,6 @@
     "processing-1279-4.0b4",
     "processing-0270-3.5.4",
     "processing-0227-2.2.1"
-  ]
+  ],
+  "selectedPreReleases": [""]
 }


### PR DESCRIPTION
This hotfix solves the issue on the download page when building. The `selected.json` was missing the definition of the `selectedPreReleases` object as an array with an empty string in order to be considered by Gatsby when building the page.