### PR TITLE
Some examples of the website ported to p5js

### DIFF
--- a/content/examples/Basics/Camera/MoveEye/liveSketch.js
+++ b/content/examples/Basics/Camera/MoveEye/liveSketch.js
@@ -1,0 +1,25 @@
+function runLiveSketch(s) {
+  
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.fill(204);
+  };
+
+  s.draw = () => {
+    s.lights();
+    s.background(0);
+    
+    // Change height of the camera with mouseY
+    s.camera(30.0, s.mouseY, 220.0, // eyeX, eyeY, eyeZ
+           0.0, 0.0, 0.0, // centerX, centerY, centerZ
+           0.0, 1.0, 0.0); // upX, upY, upZ
+
+    s.noStroke();
+    s.box(90);
+    s.stroke(255);
+    s.line(-100, 0, 0, 100, 0, 0);
+    s.line(0, -100, 0, 0, 100, 0);
+    s.line(0, 0, -100, 0, 0, 100);
+  };
+}
+

--- a/content/examples/Basics/Camera/Orthographic/liveSketch.js
+++ b/content/examples/Basics/Camera/Orthographic/liveSketch.js
@@ -1,0 +1,28 @@
+function runLiveSketch(s) {
+  let showPerspective = false;
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noFill();
+    s.fill(255);
+    s.noStroke();
+  };
+
+  s.draw = () => {
+    s.lights();
+    s.background(0);
+    let far = s.map(s.mouseX, 0, s.width, 120, 400);
+    if (showPerspective == true) {
+      s.perspective(s.PI / 3.0, s.width / s.height, 10, far);
+    } else {
+      s.ortho(-s.width / 2.0, s.width / 2.0, -s.height / 2.0, s.height / 2.0, 10, far);
+    }
+    s.rotateX(-s.PI/6);
+    s.rotateY(s.PI/3);
+    s.box(180);
+  };
+  
+  s.mousePressed = () => {
+    showPerspective = !showPerspective;
+  }
+}

--- a/content/examples/Basics/Camera/Perspective/liveSketch.js
+++ b/content/examples/Basics/Camera/Perspective/liveSketch.js
@@ -1,0 +1,27 @@
+function runLiveSketch(s) {
+  
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+  };
+
+  s.draw = () => {
+    s.lights();
+    s.background(0);
+    let cameraY = s.height/2.0;
+    let fov = s.mouseX/s.width * s.PI / 2;
+    let cameraZ = cameraY / s.tan(fov / 2.0);
+    let aspect = s.width / s.height;
+    if (s.mouseIsPressed) {
+      aspect = aspect / 2.0;
+    }
+    s.perspective(fov, aspect, cameraZ / 10.0, cameraZ * 10.0);
+    
+    s.translate(30, 0, 0);
+    s.rotateX(-s.PI / 6);
+    s.rotateY(s.PI / 3 + s.mouseY / s.height * s.PI);
+    s.box(45);
+    s.translate(0, 0, -50);
+    s.box(30);
+  };
+}

--- a/content/examples/Basics/Lights/Directional/liveSketch.js
+++ b/content/examples/Basics/Lights/Directional/liveSketch.js
@@ -1,0 +1,20 @@
+function runLiveSketch(s) {
+  
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+    s.fill(204);
+  };
+
+  s.draw = () => {
+    s.noStroke(); 
+    s.background(0); 
+    let dirY = (s.mouseY / s.height - 0.5) * 2;
+    let dirX = (s.mouseX / s.width - 0.5) * 2;
+    s.directionalLight(204, 204, 204, -dirX, -dirY, -1); 
+    s.translate(- 100, 0, 0); 
+    s.sphere(80); 
+    s.translate(200, 0, 0); 
+    s.sphere(80); 
+  };
+}

--- a/content/examples/Basics/Lights/Mixture/liveSketch.js
+++ b/content/examples/Basics/Lights/Mixture/liveSketch.js
@@ -1,0 +1,30 @@
+function runLiveSketch(s) {
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+  };
+
+  s.draw = () => {
+    s.background(0);
+  
+    // Orange point light on the right
+    s.pointLight(150, 100, 0, // Color
+               200, -150, 0); // Position
+
+    // Blue directional light from the left
+    s.directionalLight(0, 102, 255, // Color
+                     1, 0, 0); // The x-, y-, z-axis direction
+  
+    // Yellow spotlight from the front
+    s.spotLight(255, 255, 109, // Color
+              0, 40, 200, // Position
+              0, -0.5, -0.5, // Direction
+              s.PI / 2, 2); // Angle, concentration
+
+    s.rotateY(s.map(s.mouseX, 0, s.width, 0, s.PI));
+    s.rotateX(s.map(s.mouseY, 0, s.height, 0, s.PI));
+    s.box(150);
+  };
+}
+

--- a/content/examples/Basics/Lights/MixtureGrid/liveSketch.js
+++ b/content/examples/Basics/Lights/MixtureGrid/liveSketch.js
@@ -1,0 +1,41 @@
+function runLiveSketch(s) {
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+  };
+
+  s.draw = () => {
+    defineLights();
+    s.background(0);
+  
+    for (let x = 0; x <= s.width; x += 60) {
+      for (let y = 0; y <= s.height; y += 60) {
+        s.push();
+        s.translate(-s.width / 2, -s.height / 2, 0);
+        s.translate(x, y);
+        s.rotateY(s.map(s.mouseX, 0, s.width, 0, s.PI));
+        s.rotateX(s.map(s.mouseY, 0, s.height, 0, s.PI));
+        s.box(90);
+        s.pop();
+      }
+    }
+  };
+  
+  function defineLights() {
+    // Orange point light on the right
+    s.pointLight(150, 100, 0,   // Color
+               200, -150, 0); // Position
+  
+    // Blue directional light from the left
+    s.directionalLight(0, 102, 255, // Color
+                     1, 0, 0);    // The x-, y-, z-axis direction
+  
+    // Yellow spotlight from the front
+    s.spotLight(255, 255, 109,  // Color
+              0, 40, 200,     // Position
+              0, -0.5, -0.5,  // Direction
+              s.PI / 2, 2);     // Angle, concentration
+  }
+}
+

--- a/content/examples/Basics/Lights/OnOff/liveSketch.js
+++ b/content/examples/Basics/Lights/OnOff/liveSketch.js
@@ -1,0 +1,24 @@
+function runLiveSketch(s) {
+  let spin = 0.0;
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+  };
+
+  s.draw = () => {
+    s.background(51);
+  
+    if (!s.mouseIsPressed) {
+      s.lights();
+    }
+    
+    spin += 0.01;
+    
+    s.push();
+    s.rotateX(s.PI / 9);
+    s.rotateY(s.PI / 5 + spin);
+    s.box(150);
+    s.pop();
+  };
+}

--- a/content/examples/Basics/Lights/Reflection/liveSketch.js
+++ b/content/examples/Basics/Lights/Reflection/liveSketch.js
@@ -1,0 +1,20 @@
+function runLiveSketch(s) {
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+    s.colorMode(s.RGB, 1);
+    s.fill(0.4);
+  };
+
+  s.draw = () => {
+    s.background(0);
+    // Set the specular color of s.lights that follow
+    s.specularMaterial(1, 1, 1);
+    s.directionalLight(0.8, 0.8, 0.8, 0, 0, -1);
+    let r = s.mouseX / s.width;
+    //set the colour the object will reflect under *any* light
+    s.ambientMaterial(r, r, r);
+    s.sphere(120);
+  };
+}

--- a/content/examples/Basics/Transform/Rotate/liveSketch.js
+++ b/content/examples/Basics/Transform/Rotate/liveSketch.js
@@ -9,10 +9,10 @@
  * is identical to the statement scale(PI/2).
  */
 
-var angle = 0;
-var jitter = 0;
-
 function runLiveSketch(s) {
+  var angle = 0;
+  var jitter = 0;
+  
   s.setup = () => {
     s.createCanvas(640, 360);
     s.noStroke();

--- a/content/examples/Basics/Transform/RotatePushPop/liveSketch.js
+++ b/content/examples/Basics/Transform/RotatePushPop/liveSketch.js
@@ -1,0 +1,32 @@
+function runLiveSketch(s) {
+  let a;                 // Angle of rotation
+  let offset;  // Angle offset between s.boxes
+  let num;            // Number of s.boxes
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    s.noStroke();
+    
+    a = 0.;
+    offset = s.PI / 24.0;
+    num = 12;
+  };
+
+  s.draw = () => {
+    s.lights();
+  
+    s.background(0, 0, 26);
+        
+    for(let i = 0; i < num; i++) {
+      let gray = s.map(i, 0, num - 1, 0, 255);
+      s.push();
+      s.fill(gray);
+      s.rotateY(a + offset * i);
+      s.rotateX(a / 2 + offset * i);
+      s.box(200);
+      s.pop();
+    }
+    
+    a += 0.01;
+  };
+}

--- a/content/examples/Basics/Transform/RotateXY/liveSketch.js
+++ b/content/examples/Basics/Transform/RotateXY/liveSketch.js
@@ -1,0 +1,30 @@
+function runLiveSketch(s) {
+  let a = 0.0;
+  let rSize;  // s.rectangle size
+
+  s.setup = () => {
+    s.createCanvas(640, 360, s.WEBGL);
+    rSize = s.width / 6;  
+    s.noStroke();
+    s.fill(204, 204);
+  };
+
+  s.draw = () => {
+    s.background(126);
+  
+    a += 0.005;
+    if(a > s.TWO_PI) { 
+      a = 0.0; 
+    }
+    
+    s.rotateX(a);
+    s.rotateY(a * 2.0);
+    s.fill(255);
+    s.rect(-rSize, -rSize, rSize*2, rSize*2);
+    
+    s.rotateX(a * 1.001);
+    s.rotateY(a * 2.002);
+    s.fill(0);
+    s.rect(-rSize, -rSize, rSize*2, rSize*2);
+  };
+}


### PR DESCRIPTION
1. Partially fixes #235.
2. Also adds a minor modification to the [Rotate](https://processing.org/examples/rotate.html) example to prevent  its variables to be in the global scope of the webpage; see [global vs instance mode](https://github.com/processing/p5.js/wiki/Global-and-instance-mode).
3. Solves [issue](https://github.com/processing/processing-examples/issues/2) from processing-examples repository.