### PR TITLE
delete "new" wording in Processing Sound

### DIFF
--- a/content/pages/libraries/sound/index.mdx
+++ b/content/pages/libraries/sound/index.mdx
@@ -7,6 +7,6 @@ description: 'Playback audio files, audio input, synthesize sound, and effects.'
 
 ## Sound
 
-The new Sound library for Processing 3 provides a simple way to work with audio. It can play, analyze, and synthesize sound. It provides a collection of oscillators for basic wave forms, a variety of noise generators, and effects and filters to play and alter sound files and other generated sounds. The syntax is minimal to make it easy to patch one sound object into another. The library also comes with example sketches covering many use cases to help you get started.
+The Sound library for Processing provides a simple way to work with audio. It can play, analyze, and synthesize sound. It provides a collection of oscillators for basic wave forms, a variety of noise generators, and effects and filters to play and alter sound files and other generated sounds. The syntax is minimal to make it easy to patch one sound object into another. The library also comes with example sketches covering many use cases to help you get started.
 
 The source code is available on the processing-sound GitHub repository. Please report bugs here. This library is only compatible with Processing 3.0+.


### PR DESCRIPTION
the library has been available since Processing 3.0, so it doesn't need that sentence.