### PR TITLE
Adding sitewide banner

### DIFF
--- a/content/sitewide/banner.json
+++ b/content/sitewide/banner.json
@@ -1,5 +1,5 @@
 {
-  "visible": false,
+  "visible": true,
   "text": "This is some text",
   "url": "https://designsystems.international"
 }

--- a/content/sitewide/banner.json
+++ b/content/sitewide/banner.json
@@ -1,0 +1,5 @@
+{
+  "visible": false,
+  "text": "This is some text",
+  "url": "https://designsystems.international"
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -56,6 +56,13 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        name: `sitewide`,
+        path: path.resolve(__dirname, 'content/sitewide')
+      }
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         name: `images`,
         path: path.resolve(__dirname, 'src/images')
       }

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -1,0 +1,12 @@
+import React, { memo } from 'react';
+import * as css from './Banner.module.css';
+
+export const Banner = ({ text, url }) => {
+  return (
+    <a href={url} target="_blank" className={css.root}>
+      {text}
+    </a>
+  );
+};
+
+export default memo(Banner);

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -1,12 +1,45 @@
-import React, { memo } from 'react';
+import React, { memo, useEffect, useState } from 'react';
+import { slugify } from '../utils';
 import * as css from './Banner.module.css';
 
 export const Banner = ({ text, url }) => {
-  return (
-    <a href={url} target="_blank" className={css.root}>
-      {text}
-    </a>
-  );
+  const [visible, setVisible] = useState(false);
+  const key = slugify(text);
+
+  const hide = () => {
+    if (window.localStorage) {
+      window.localStorage.setItem(
+        `banner-${key}`,
+        JSON.stringify({
+          visible: false
+        })
+      );
+    }
+    setVisible(false);
+  };
+
+  // Only show the banner if this text has not been dismissed yet
+  useEffect(() => {
+    if (window.localStorage) {
+      const savedState = window.localStorage.getItem(`banner-${key}`);
+      if (savedState) {
+        setVisible(JSON.parse(savedState).visible);
+      } else {
+        setVisible(true);
+      }
+    }
+  }, [key]);
+
+  return visible ? (
+    <div className={css.root}>
+      <a className={css.link} href={url} target="_blank" rel="noreferrer">
+        {text}
+      </a>
+      <button className={css.close} onClick={hide}>
+        x
+      </button>
+    </div>
+  ) : null;
 };
 
 export default memo(Banner);

--- a/src/components/Banner.module.css
+++ b/src/components/Banner.module.css
@@ -1,0 +1,9 @@
+.root {
+  display: block;
+  text-align: center;
+  background-color: var(--processing-blue-gradient);
+  padding: var(--margin-quarter);
+  font-size: var(--text-small);
+  color: var(--processing-blue-dark);
+  margin-top: -2px;
+}

--- a/src/components/Banner.module.css
+++ b/src/components/Banner.module.css
@@ -1,9 +1,23 @@
 .root {
-  display: block;
   text-align: center;
-  background-color: var(--processing-blue-gradient);
-  padding: var(--margin-quarter);
-  font-size: var(--text-small);
-  color: var(--processing-blue-dark);
+  background-color: var(--processing-blue-deep);
+  color: white;
+  font-size: var(--text-normal);
   margin-top: -2px;
+  display: flex;
+}
+
+.link {
+  display: block;
+  padding: var(--margin-quarter);
+  flex: 1;
+}
+
+.close {
+  flex: 0 0 60px;
+  cursor: pointer;
+  background: none;
+  color: white;
+  border: none;
+  font-size: var(--text-large);
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,15 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { graphql, useStaticQuery } from 'gatsby';
 
 import Topbar from './Topbar';
 import Navbar from './Navbar';
+import Banner from './Banner';
 
 import * as css from './Header.module.css';
 
 const Header = ({ siteTitle, scrolled }) => {
+  const data = useStaticQuery(graphql`
+    query {
+      banner: file(
+        name: { eq: "banner" }
+        sourceInstanceName: { eq: "sitewide" }
+      ) {
+        name
+        childJson {
+          visible
+          url
+          text
+        }
+      }
+    }
+  `);
+  const bannerData = data.banner.childJson;
+
   return (
     <header className={css.root}>
       <Topbar show={!scrolled} />
+      {bannerData && bannerData.visible && <Banner {...bannerData} />}
       <Navbar siteTitle={siteTitle} scrolled={scrolled} />
     </header>
   );


### PR DESCRIPTION
This PR implements a sitewide banner that can link to an external site. I introduced a new `content/sitewide` folder to store settings like this, and the `banner.json` file has the following settings:

- `visible` : A boolean that set to `true` will show the banner
- `text` : The text to be shown on the banner
- `url` : The full URL to link to

@SableRaf You should be able to tweak the JSON and publish the site to show the banner, but please let me know if you need any help with this :) 