### PR TITLE
Improved fetchreleases

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -6,8 +6,11 @@ In order to not require an API token on GitHub in development, there is a separa
 
 ## How to show a new release on the download page
 
-1. Make sure `npm` is up to date
+1. Make sure `npm` is up to date. (Check Node.js version with `node -v` and make sure it corresponds to the version in [`/.github/workflows/deploy.yml`](https://github.com/processing/processing-website/blob/main/.github/workflows/deploy.yml). For example, if the version specified in the deploy.yml file is `node-version: 16.x` then `v16.17.0` would be a match.)
 1. Make sure that the release has been published on GitHub
-1. Run the script with a GitHub token: `$ GITHUB_TOKEN=SOMETOKENHERE npm run fetchReleases`
-1. Edit the [`selected.json`](/content/download/selected.json) file to include the new release tag
-1. Make a PR to the `main` branch.
+1. Create a [GitHub access token](https://github.com/settings/tokens)
+1. Create a git branch to hold your changes
+1. Run the script with: `npm run fetchReleases`
+1. Enter your GitHub access token when prompted
+1. Edit the [`/content/download/selected.json`](/content/download/selected.json) file to include the new release tag
+1. Make a pull request to the `main` branch

--- a/scripts/fetchReleases.js
+++ b/scripts/fetchReleases.js
@@ -1,8 +1,9 @@
+const readline = require('readline');
 const { graphql } = require('@octokit/graphql');
 const fs = require('fs');
 const path = require('path');
 
-const fetchReleases = async () => {
+const fetchReleases = async (githubToken) => {
   const { processing, processing4 } = await graphql(
     `
       query {
@@ -48,7 +49,7 @@ const fetchReleases = async () => {
     `,
     {
       headers: {
-        authorization: `token ${process.env.GITHUB_TOKEN}`
+        authorization: `token ${githubToken}`
       }
     }
   );
@@ -71,10 +72,14 @@ const fetchReleases = async () => {
   });
 };
 
-// only fetch if ENV has GITHUB_TOKEN
-if (process.env.GITHUB_TOKEN) {
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.question('Please enter your GitHub token: ', (token) => {
+  rl.close();
+
   console.log('Fetching releases from github.com');
-  fetchReleases();
-} else {
-  console.log('No GitHub token found. Bypassing fetch of releases');
-}
+  fetchReleases(token);
+});


### PR DESCRIPTION
* updated the fetchReleases script to request the GitHub authorization token at runtime and avoid storing it in an environment variable.
* clarified the instructions for making a new release + update the instructions to match the new way to enter the token