### PR TITLE
Updated documentation for compound assignment operators to improve consistency

### DIFF
--- a/content/references/translations/en/processing/addassign.json
+++ b/content/references/translations/en/processing/addassign.json
@@ -3,20 +3,20 @@
   "brief": "Combines addition with assignment",
   "description": "Combines addition with assignment. The expression <b>a += b</b> is equivalent to <b>a = a + b</b>. \n",
   "related": ["assign", "addition", "subtractassign"],
-  "syntax": ["value1 += value2"],
+  "syntax": ["var += value"],
   "returns": "",
   "type": "function",
   "category": "math",
   "subcategory": "Operators",
   "parameters": [
     {
-      "name": "value1",
+      "name": "var",
       "description": "int or float",
       "type": []
     },
     {
-      "name": "value2",
-      "description": "any numerical value the same datatype as value1",
+      "name": "value",
+      "description": "any numerical value the same datatype as var",
       "type": []
     }
   ]

--- a/content/references/translations/en/processing/divideassign.json
+++ b/content/references/translations/en/processing/divideassign.json
@@ -3,16 +3,16 @@
   "brief": "Combines division with assignment",
   "description": "Combines division with assignment. The expression <b>a /= b</b> is equivalent to <b>a = a / b</b>. \n",
   "related": ["divide", "assign"],
-  "syntax": ["value1 /= value2"],
+  "syntax": ["var /= value"],
   "returns": "",
   "type": "function",
   "category": "math",
   "subcategory": "Operators",
   "parameters": [
-    { "name": "value1", "description": "int or float", "type": [] },
+    { "name": "var", "description": "int or float", "type": [] },
     {
-      "name": "value2",
-      "description": "any numerical value the same datatype as value1",
+      "name": "value",
+      "description": "any numerical value the same datatype as var",
       "type": []
     }
   ]

--- a/content/references/translations/en/processing/multiplyassign.json
+++ b/content/references/translations/en/processing/multiplyassign.json
@@ -3,15 +3,15 @@
   "brief": "Combines multiplication with assignment",
   "description": "Combines multiplication with assignment. The expression <b>a *= b</b> is equivalent to <b>a = a * b</b>. \n",
   "related": ["multiply", "assign"],
-  "syntax": ["value1 *= value2"],
+  "syntax": ["var *= value"],
   "returns": "",
   "type": "function",
   "category": "math",
   "subcategory": "Operators",
   "parameters": [
-    { "name": "value1", "description": "int or float", "type": [] },
+    { "name": "var", "description": "int or float", "type": [] },
     {
-      "name": "value2",
+      "name": "value",
       "description": "any numerical value the same datatype as value1",
       "type": []
     }

--- a/content/references/translations/en/processing/subtractassign.json
+++ b/content/references/translations/en/processing/subtractassign.json
@@ -3,13 +3,13 @@
   "brief": "Combines subtraction with assignment",
   "description": "Combines subtraction with assignment. The expression <b>a -= b</b> is equivalent to <b>a = a - b</b>. \n",
   "related": ["addassign", "minus"],
-  "syntax": ["value1 -= value2"],
+  "syntax": ["var -= value"],
   "returns": "",
   "type": "function",
   "category": "math",
   "subcategory": "Operators",
   "parameters": [
-    { "name": "value1", "description": "int or float", "type": [] },
-    { "name": "value2", "description": "int or float", "type": [] }
+    { "name": "var", "description": "int or float", "type": [] },
+    { "name": "value", "description": "any numerical value the same datatype as var", "type": [] }
   ]
 }


### PR DESCRIPTION
Issue: https://github.com/processing/processing-website/issues/411

Previously, the documentation for compound assignment operators was not consistent with the documentation for [add assign operator.](https://processing.org/reference/assign.html) The new documentation contains updated syntax and parameters for += /= -= *=.

@SableRaf 