### PR TITLE
FIxed social media links to open in new page

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -20,16 +20,16 @@ const Footer = ({ withSidebar }) => {
       <div className={classnames(grid.col, css.socialmediaWrapper)}>
         <ul>
           <li>
-            <a href={'https://twitter.com/ProcessingOrg'}>Twitter</a>
+            <a href={'https://twitter.com/ProcessingOrg'} target="_blank">Twitter</a>
           </li>
           <li>
-            <a href={'https://medium.com/@ProcessingOrg'}>Medium</a>
+            <a href={'https://medium.com/@ProcessingOrg'} target="_blank">Medium</a>
           </li>
           <li>
-            <a href={'https://www.instagram.com/processingorg/'}>Instagram</a>
+            <a href={'https://www.instagram.com/processingorg/'} target="_blank">Instagram</a>
           </li>
           <li>
-            <a href={'http://github.com/processing/'}>GitHub</a>
+            <a href={'http://github.com/processing/'} target="_blank">GitHub</a>
           </li>
         </ul>
         <p


### PR DESCRIPTION
Issue: https://github.com/processing/processing-website/issues/424

Previously, the social media links in the footer of the [processing website](https://processing.org/) did not open in a new tab. This has been fixed. 