### PR TITLE
changed the color contrast between background and hover color in footer.

### DIFF
--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -18,6 +18,9 @@
   & a {
     text-decoration: underline;
   }
+  & a:hover {
+    color: var(--footer-hover);
+  }
 }
 
 .root.withSidebar {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -37,6 +37,8 @@
   --download-inactive: #8890B3;
   --download-background-active: rgba(80, 139, 255, 0.08);
 
+  --footer-hover:#ffffc2;
+
   --text-xsmall: 0.8rem;
   --text-small: 0.875rem;
   --text-regular: 1rem;


### PR DESCRIPTION
changed the color contrast between background and hover color in footer, so the people with color blindness can also read clearly.
Before the hover color of anchor tag used to be like this:
![image](https://user-images.githubusercontent.com/89389741/218319302-118af91d-0f8a-45aa-85c6-b91f53ac99db.png)
After that I changed the color to Parchment as u can see below:
![image](https://user-images.githubusercontent.com/89389741/218319179-8418f462-d405-42d3-994f-7202c8e0168a.png)
