### PR TITLE
Low contrast between background and foreground colors (text)

### DIFF
--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -18,6 +18,9 @@
   & a {
     text-decoration: underline;
   }
+  & a:hover {
+    color: var(--footer-hover);
+  }
 }
 
 .root.withSidebar {

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -138,6 +138,10 @@
 .card:active {
   border-color: var(--processing-blue-mid);
   background: var(--processing-blue-mid);
+
+   & p{
+    color: white;
+  }
 }
 
 /*  Participate */

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -37,6 +37,8 @@
   --download-inactive: #8890B3;
   --download-background-active: rgba(80, 139, 255, 0.08);
 
+  --footer-hover:#ffffc2;
+
   --text-xsmall: 0.8rem;
   --text-small: 0.875rem;
   --text-regular: 1rem;


### PR DESCRIPTION
worked on issue #427 .
changed the color contrast between background and hover color in footer, so the people with color blindness can also read clearly.
Before the hover color of anchor tag used to be like this:
![image](https://user-images.githubusercontent.com/89389741/218465662-6e063df4-ef68-422c-9aa0-fde13a4af549.png)
to this:
![Screenshot_20230213_062854](https://user-images.githubusercontent.com/89389741/218465775-deaaf466-761e-4333-9df7-02037bcb1624.png)

Changes made on footer:
![Screenshot_20230212_084104](https://user-images.githubusercontent.com/89389741/218465996-8ed9026a-33fa-45d5-b817-2a76859d5c0b.png)
 to this:
![Screenshot_20230212_083818](https://user-images.githubusercontent.com/89389741/218466096-f4c1c16c-f77f-4de3-b081-4dcd0c55a64d.png)
I'm new to open source contributions. Can I work further on this issue #427 to improve the website? 
Any advice will be appreciated :)