### PR TITLE
Issue: Environment (IDE) textResponsive

### DIFF
--- a/src/pages/environment.js
+++ b/src/pages/environment.js
@@ -42,8 +42,8 @@ const Environment = ({ data }) => {
           <Content sidebarOpen={showSidebar} className={css.contentWrapper}>
             <h1>{mdx.frontmatter.title}</h1>
             <div className={css.content}>
-              <MDXRenderer>{mdx.body}</MDXRenderer>
             </div>
+              <div className={css.environmentBody}><MDXRenderer>{mdx.body}</MDXRenderer></div>
           </Content>
         ) : (
           <Content sidebarOpen={showSidebar}>

--- a/src/styles/pages/page.module.css
+++ b/src/styles/pages/page.module.css
@@ -19,6 +19,9 @@
     margin-top: var(--vertical-margin-large);
     margin-bottom: 1rem;
     clear: right;
+    
+    
+    
   }
 
   & h3 {
@@ -159,4 +162,10 @@
       margin-left: 0;
     }
   }
+}
+
+.environmentBody{
+  font-family: "Vollkorn", serif;
+  font-size: var(--text-medium);
+  line-height: 1.6em;
 }


### PR DESCRIPTION
Hey, I think so this was a bug for the mobile user on processing.org/environment/ page the text is not responsive. It only takes 50-60% of the screen size of mobile devices. 

Solution:
So, make some changes to environment.js
previously the environment page text is not much responsive for the mobile screen size So I made some changes to fix it
Before:
![p5js](https://user-images.githubusercontent.com/97503662/222207710-d0e6f9c8-6f94-400d-8862-323112159c53.JPG)
After:
![p5js new](https://user-images.githubusercontent.com/97503662/222208012-ec43b8f1-a9c6-41e6-9b63-6f4afb4fee86.JPG)
