### PR TITLE
Clarified vertex() parameters

### DIFF
--- a/content/references/examples/processing/vertex_/vertex_2.pde
+++ b/content/references/examples/processing/vertex_/vertex_2.pde
@@ -5,7 +5,7 @@ beginShape();
 texture(img);
 // "laDefense.jpg" is 100x100 pixels in size so
 // the values 0 and 400 are used for the
-// parameters "u" and "v" to map it directly
+// parameters "xTexture" and "yTexture" to map it directly
 // to the vertex points
 vertex(40, 80, 0, 0);
 vertex(320, 20, 100, 0);

--- a/content/references/translations/en/processing/vertex_.json
+++ b/content/references/translations/en/processing/vertex_.json
@@ -9,13 +9,13 @@
     "texture_"
   ],
   "name": "vertex()",
-  "description": "All shapes are constructed by connecting a series of vertices.\n <b>vertex()</b> is used to specify the vertex coordinates for points, lines,\n triangles, quads, and polygons. It is used exclusively within the\n <b>beginShape()</b> and <b>endShape()</b> functions. <br />\n <br />\n Drawing a vertex in 3D using the <b>z</b> parameter requires the P3D\n parameter in combination with size, as shown in the above example. <br />\n <br />\n This function is also used to map a texture onto geometry. The\n <b>texture()</b> function declares the texture to apply to the geometry and\n the <b>u</b> and <b>v</b> coordinates set define the mapping of this texture\n to the form. By default, the coordinates used for <b>u</b> and <b>v</b> are\n specified in relation to the image's size in pixels, but this relation can be\n changed with <b>textureMode()</b>.",
+  "description": "All shapes are constructed by connecting a series of vertices.\n <b>vertex()</b> is used to specify the vertex coordinates for points, lines,\n triangles, quads, and polygons. It is used exclusively within the\n <b>beginShape()</b> and <b>endShape()</b> functions. <br />\n <br />\n Drawing a vertex in 3D using the <b>z</b> parameter requires the P3D\n parameter in combination with size, as shown in the above example. <br />\n <br />\n This function is also used to map a texture onto geometry. The\n <b>texture()</b> function declares the texture to apply to the geometry and\n the <b>xTexture</b> and <b>yTexture</b> coordinates set define the mapping of this texture\n to the form. By default, the coordinates used for <b>xTexture</b> and <b>yTexture</b> are\n specified in relation to the image's size in pixels, but this relation can be\n changed with <b>textureMode()</b>.",
   "syntax": [
     "vertex(x, y)",
     "vertex(x, y, z)",
-    "vertex(v)",
-    "vertex(x, y, u, v)",
-    "vertex(x, y, z, u, v)"
+    "vertex(point)",
+    "vertex(x, y, xTexture, yTexture)",
+    "vertex(x, y, z, xTexture, yTexture)"
   ],
   "returns": "void",
   "type": "function",
@@ -23,9 +23,9 @@
   "subcategory": "vertex",
   "parameters": [
     {
-      "name": "v",
+      "name": "point",
       "description": "vertex parameters, as a float array of length VERTEX_FIELD_COUNT",
-      "type": ["float[]", "float"]
+      "type": ["float[]"]
     },
     {
       "name": "x",
@@ -43,14 +43,14 @@
       "type": ["float"]
     },
     {
-      "name": "u",
+      "name": "xTexture",
       "description": "horizontal coordinate for the texture mapping",
       "type": ["float"]
     },
     {
-      "name": "v",
+      "name": "yTexture",
       "description": "vertical coordinate for the texture mapping",
-      "type": ["float", "float[]"]
+      "type": ["float"]
     }
   ]
 }

--- a/content/references/translations/es/processing/vertex_.es.json
+++ b/content/references/translations/es/processing/vertex_.es.json
@@ -9,13 +9,13 @@
     "texture_"
   ],
   "name": "vertex()",
-  "description": "All shapes are constructed by connecting a series of vertices.\n <b>vertex()</b> is used to specify the vertex coordinates for points, lines,\n triangles, quads, and polygons. It is used exclusively within the\n <b>beginShape()</b> and <b>endShape()</b> functions. <br />\n <br />\n Drawing a vertex in 3D using the <b>z</b> parameter requires the P3D\n parameter in combination with size, as shown in the above example. <br />\n <br />\n This function is also used to map a texture onto geometry. The\n <b>texture()</b> function declares the texture to apply to the geometry and\n the <b>u</b> and <b>v</b> coordinates set define the mapping of this texture\n to the form. By default, the coordinates used for <b>u</b> and <b>v</b> are\n specified in relation to the image's size in pixels, but this relation can be\n changed with <b>textureMode()</b>.",
+  "description": "All shapes are constructed by connecting a series of vertices.\n <b>vertex()</b> is used to specify the vertex coordinates for points, lines,\n triangles, quads, and polygons. It is used exclusively within the\n <b>beginShape()</b> and <b>endShape()</b> functions. <br />\n <br />\n Drawing a vertex in 3D using the <b>z</b> parameter requires the P3D\n parameter in combination with size, as shown in the above example. <br />\n <br />\n This function is also used to map a texture onto geometry. The\n <b>texture()</b> function declares the texture to apply to the geometry and\n the <b>xTexture</b> and <b>yTexture</b> coordinates set define the mapping of this texture\n to the form. By default, the coordinates used for <b>xTexture</b> and <b>yTexture</b> are\n specified in relation to the image's size in pixels, but this relation can be\n changed with <b>textureMode()</b>.",
   "syntax": [
     "vertex(x, y)",
     "vertex(x, y, z)",
-    "vertex(v)",
-    "vertex(x, y, u, v)",
-    "vertex(x, y, z, u, v)"
+    "vertex(point)",
+    "vertex(x, y, xTexture, yTexture)",
+    "vertex(x, y, z, xTexture, yTexture)"
   ],
   "returns": "void",
   "type": "function",
@@ -23,9 +23,9 @@
   "subcategory": "vertex",
   "parameters": [
     {
-      "name": "v",
+      "name": "point",
       "description": "vertex parameters, as a float array of length VERTEX_FIELD_COUNT",
-      "type": ["float[]", "float"]
+      "type": ["float[]"]
     },
     {
       "name": "x",
@@ -43,14 +43,14 @@
       "type": ["float"]
     },
     {
-      "name": "u",
+      "name": "xTexture",
       "description": "horizontal coordinate for the texture mapping",
       "type": ["float"]
     },
     {
-      "name": "v",
+      "name": "yTexture",
       "description": "vertical coordinate for the texture mapping",
-      "type": ["float", "float[]"]
+      "type": ["float"]
     }
   ]
 }


### PR DESCRIPTION
Completed Issue #350, as well as fixed up other errors found in the document for vertex().
I changed both the en and es versions and an example to match the new parameters. 
I will begin working on fixing the actual processing4 code itself to reflect these changes in documentation.