### PR TITLE
Add fathom plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -203,8 +203,6 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-fathom',
       options: {
-        // Your custom domain, defaults to `cdn.usefathom.com`
-        trackingUrl: 'processing.org',
         // Unique site id
         siteId: 'DKYMXLKT'
       }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -199,6 +199,15 @@ module.exports = {
           include: path.resolve(__dirname, 'src/images')
         }
       }
+    },
+    {
+      resolve: 'gatsby-plugin-fathom',
+      options: {
+        // Your custom domain, defaults to `cdn.usefathom.com`
+        trackingUrl: 'processing.org',
+        // Unique site id
+        siteId: 'DKYMXLKT'
+      }
     }
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "classnames": "^2.3.1",
         "copy-to-clipboard": "^3.3.2",
         "gatsby": "^4.22.0",
+        "gatsby-plugin-fathom": "^2.1.1",
         "gatsby-plugin-image": "^2.22.0",
         "gatsby-plugin-manifest": "^4.22.0",
         "gatsby-plugin-mdx": "2.14.2",
@@ -10975,6 +10976,29 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-fathom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-fathom/-/gatsby-plugin-fathom-2.1.1.tgz",
+      "integrity": "sha512-t5xtF+Mo7x8GPhBO0gX3DF2slAfSXmut7u+IKkZ03sIvzlJ9VKaGMI1tetKxhe8/3Vylq7edn6lgZoiIjKDU3Q==",
+      "dependencies": {
+        "@babel/runtime": "7.14.5"
+      },
+      "peerDependencies": {
+        "gatsby": ">=2.0.0",
+        "react": ">=16.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-fathom/node_modules/@babel/runtime": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.5.tgz",
+      "integrity": "sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/gatsby-plugin-image": {
@@ -32002,6 +32026,24 @@
         "@parcel/transformer-json": "2.6.2",
         "@parcel/transformer-raw": "2.6.2",
         "@parcel/transformer-react-refresh-wrap": "2.6.2"
+      }
+    },
+    "gatsby-plugin-fathom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-fathom/-/gatsby-plugin-fathom-2.1.1.tgz",
+      "integrity": "sha512-t5xtF+Mo7x8GPhBO0gX3DF2slAfSXmut7u+IKkZ03sIvzlJ9VKaGMI1tetKxhe8/3Vylq7edn6lgZoiIjKDU3Q==",
+      "requires": {
+        "@babel/runtime": "7.14.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.5.tgz",
+          "integrity": "sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "gatsby-plugin-image": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "classnames": "^2.3.1",
     "copy-to-clipboard": "^3.3.2",
     "gatsby": "^4.22.0",
+    "gatsby-plugin-fathom": "^2.1.1",
     "gatsby-plugin-image": "^2.22.0",
     "gatsby-plugin-manifest": "^4.22.0",
     "gatsby-plugin-mdx": "2.14.2",


### PR DESCRIPTION
This pull request adds Fathom Analytics to the Processing.org website.

Changes include:
- Installation of the `gatsby-plugin-fathom` package.
- Configuration of the Fathom plugin with our site ID in the `gatsby-config.js` file.

These changes allow us to track visitor data without compromising on user privacy as Fathom is a privacy-focused analytics service. Note that Fathom analytics is GDPR compliant by default.