### PR TITLE
Fixed link on PFont resource page, file PFont.json

### DIFF
--- a/content/references/translations/en/processing/PFont.json
+++ b/content/references/translations/en/processing/PFont.json
@@ -1,7 +1,7 @@
 {
   "brief": "Grayscale bitmap font class used by Processing",
   "constructors": [],
-  "related": ["loadFont_", "createFont_", "PGraphics_textFont_"],
+  "related": ["loadFont_", "createFont_", "textFont_"],
   "methods": [
     {
       "anchor": "PFont_list_",


### PR DESCRIPTION
This PR Fixes #468. 

I corrected the link at the bottom of this page: https://processing.org/reference/PFont.html.
Instead of going to: https://processing.org/reference/PGraphics_textFont_.html
It now goes to: https://processing.org/reference/textFont_.html

# Before:
![BeforeLinkFix#468](https://github.com/processing/processing-website/assets/124199231/2dfe73f2-ca93-4b6c-95da-5caae435b6ea)

# After:
![AfterLinkFix#468](https://github.com/processing/processing-website/assets/124199231/6417138b-c635-44eb-8fe4-2493201a4683)

Page: https://processing.org/reference/PFont.html