### PR TITLE
fix: Renamed "Featured functions" to a More Generic Term (Issue: #465)

### DIFF
--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -126,7 +126,7 @@
   "related": "Related",
   "notTranslated": "This page is not translated, please refer to the",
   "englishPage": "english page",
-  "featured": "Featured functions",
+  "featured": "Key Elements",
   "relatedExamples": "Related Examples",
   "exampleInfo": "This example is for Processing 4+. If you have a previous version, use the examples included with your software. If you see any errors or have suggestions, please",
   "letUsKnow": " let us know",


### PR DESCRIPTION
fixed issue #465 

Renamed the 'featured' on file - i18n/react-intl/en.json
---------------------------------------
 "featured": "Key Elements",
 --------------------------------------