### PR TITLE
Feat/#312 describe function to live examples

### DIFF
--- a/content/examples/Basics/Color/ColorVariables/liveSketch.js
+++ b/content/examples/Basics/Color/ColorVariables/liveSketch.js
@@ -5,6 +5,12 @@
  * in the program by a name, rather than a number.
  */
 
+function describe() {
+  const description = "There are two sets of squares. The first set contains three squares of varying sizes stacked together. The color of the smallest square is orange, the color of the middle square is gold, and the color of the biggest square is brown.  On the right of the first set is the second set, which is similar to the first. The only difference here is the color of the squares; the smallest square is gold, the middle square is brown, and the biggest square is orange."
+
+  return description;
+}
+
 function runLiveSketch(s) {
   s.setup = () => {
     s.createCanvas(640, 360);

--- a/content/examples/Basics/Lights/Directional/liveSketch.js
+++ b/content/examples/Basics/Lights/Directional/liveSketch.js
@@ -1,3 +1,9 @@
+function describe() {
+  const description = "There are two dark spheres side by side, the cursor works like a light source, when mouse moves the direction of light changes and reveals some part of spheres."
+
+  return description;
+}
+
 function runLiveSketch(s) {
   
   s.setup = () => {


### PR DESCRIPTION
Addresses Issue: #312 

Add the `describe()` function to the `liveSketch.js` examples rather than the `.pde` files.
Please review the changes and provide some feedback on whether this should be modified. 
Hope you'll consider this.