### PR TITLE
fixups for the contributor page

### DIFF
--- a/content/pages/people/index.es.mdx
+++ b/content/pages/people/index.es.mdx
@@ -50,7 +50,7 @@ El núcleo del software Processing es potenciado por [bibliotecas](https://www.p
 - Harshani Nawarathna,  Entorno de Desarrollo Processing (Processing Development Environment) (Verano 2011)
 - Cindy Chi, Edición de Referencias (Verano 2011)
 - Jonathan Feinberg, Parsing & Android Hacking (Primavera 2011)
-- Chris Lonnen, Entorno de Desarrollo Processing (Processing Development Environment) (Verano 2011)
+- Lonnen, Entorno de Desarrollo Processing (Processing Development Environment) (Verano 2010 - Invierno 2010)
 - Eric Jordan, Arma de Gráficos (2007 - 2009)
 - Tom Carden, Director Processing Hacks  (Verano 2005 - Otoño 2008)
 - Lenny Burdette, Renovación de Sitio Web (Verano 2005 - Invierno 2006)

--- a/content/pages/people/index.mdx
+++ b/content/pages/people/index.mdx
@@ -50,7 +50,7 @@ The core Processing software is augmented by [libraries](https://www.processing.
 - Harshani Nawarathna, Processing Development Environment (Summer 2011)
 - Cindy Chi, Reference Editing (Summer 2011)
 - Jonathan Feinberg, Parsing & Android Hacking (Spring 2011)
-- Chris Lonnen, Processing Development Environment (Summer 2011)
+- Lonnen, Processing Development Environment (Summer 2010 - Winter 2010)
 - Eric Jordan, Graphics Weapon (2007 - 2009)
 - Tom Carden, Processing Hacks Director (Summer 2005 - Fall 2008)
 - Lenny Burdette, Website renovation (Summer 2005 - Winter 2006)


### PR DESCRIPTION
Hey -- 

this updates my information on the contributor page. I was active from Summer 2010 to December 2010 and I consistently go by my surname now in most places