### PR TITLE
fix: Renaming "Featured Functions" to "Core Elements" 

### DIFF
--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -126,7 +126,7 @@
   "related": "Related",
   "notTranslated": "This page is not translated, please refer to the",
   "englishPage": "english page",
-  "featured": "Featured functions",
+  "featured": "Core Elements",
   "relatedExamples": "Related Examples",
   "exampleInfo": "This example is for Processing 4+. If you have a previous version, use the examples included with your software. If you see any errors or have suggestions, please",
   "letUsKnow": " let us know",


### PR DESCRIPTION
fixes #465 

In the examples pages, the section termed as **"Featured functions"** is changed as **"Core Elements"** which sounds more generic and it leaves no confusion as it is pointing to both of functions and keywords.