### PR TITLE
Changed cursor to pointer on plus and minus button from sidebar

### DIFF
--- a/src/components/SidebarGroup.module.css
+++ b/src/components/SidebarGroup.module.css
@@ -73,6 +73,7 @@
   display: flex;
   flex-direction: row;
   align-items: baseline;
+  cursor: pointer;
 
   & .button {
     color: var(--processing-blue-dark);


### PR DESCRIPTION
**Fixes #493** 

The issue that is resolved by this pull request was, when we go to any reference/[any_url] and click on any specific topic, from sidebar, hovering over sidebar plus and minus icons, the cursor was not pointer. Now the cursor is pointer to all the links you visit from reference/[any_url]. Check the below video provided. Thanks.


https://github.com/processing/processing-website/assets/125039325/f8b7dceb-ca70-4b69-96d9-afce13437fb5


