### PR TITLE
 Fix: Placeholder Text Issue in Search Input

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -40,7 +40,7 @@ const SearchBar = ({ className }) => {
           onBlur={() => setFocused(false)}
           onKeyDown={onKeyDown}
           placeholder={intl.formatMessage({
-            id: focused ? 'searchWithGoogle' : 'search'
+            id: 'searchWithGoogle'
           })}
         />
         <button


### PR DESCRIPTION
Fixes: #502

## Description
This pull request addresses the issue where the placeholder text in the search input box on the p5.js website changes unexpectedly. The placeholder text is set to 'Search' initially, but when a user clicks on the input box, it changes to 'Search with Google.'

## Changes Made:

Modified the code to ensure that the placeholder text remains consistent as 'Search with Google' both before and after clicking on the search input box.

## Video:
https://github.com/processing/processing-website/assets/94161758/ba5da913-45b8-4c02-a7d8-215465d0f472

