### PR TITLE
Fix: Search Input Placeholder Text Inconsistency

### DIFF
--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -17,7 +17,7 @@
   "overview": "Overview",
   "people": "People",
   "donate": "Donate",
-  "search": "Search with Googl",
+  "search": "Search with Google",
   "searchWithGoogle": "Search with Google",
   "introTitle": "Welcome to Processing!",
   "introText": "Processing is a flexible software sketchbook and a language for learning how to code. Since 2001, Processing has promoted software literacy within the visual arts and visual literacy within technology. There are tens of thousands of students, artists, designers, researchers, and hobbyists who use Processing for learning and prototyping.",

--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -17,7 +17,7 @@
   "overview": "Overview",
   "people": "People",
   "donate": "Donate",
-  "search": "Search",
+  "search": "Search with Googl",
   "searchWithGoogle": "Search with Google",
   "introTitle": "Welcome to Processing!",
   "introText": "Processing is a flexible software sketchbook and a language for learning how to code. Since 2001, Processing has promoted software literacy within the visual arts and visual literacy within technology. There are tens of thousands of students, artists, designers, researchers, and hobbyists who use Processing for learning and prototyping.",

--- a/i18n/react-intl/es.json
+++ b/i18n/react-intl/es.json
@@ -17,7 +17,7 @@
   "overview": "Vista General",
   "people": "Personas",
   "donate": "Donar",
-  "search": "Buscar",
+  "search": "Buscar con Google",
   "searchWithGoogle": "Buscar con Google",
   "introTitle": "¡Bienvenido a Processing!",
   "introText": "Processing es un software flexible para bosquejar y un lenguaje para aprender cómo programar dentro del contexto de las artes visuales. Desde el 2001 Processing ha promovido el conocimiento de software dentro de las artes visuales y el conocimiento de las artes visuales dentro de la tecnología.Hay decenas de miles de estudiantes, artistas, diseñadores investigadores y entusiastas que usan Processing para aprender y prototipar.",

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -40,7 +40,7 @@ const SearchBar = ({ className }) => {
           onBlur={() => setFocused(false)}
           onKeyDown={onKeyDown}
           placeholder={intl.formatMessage({
-            id: focused ? 'searchWithGoogle' : 'search'
+            id: 'searchWithGoogle'
           })}
         />
         <button


### PR DESCRIPTION

## Issue
The placeholder text in the search input on the Processing website shows inconsistency. Initially, it displays 'Search,' but upon clicking the input box, it changes to 'Search with Google,' deviating from the expected behavior of consistently displaying 'Search with Google.'

Fixes Issue: #502 

## Changes Made
1. Modified the `id` property for the search input to ensure the placeholder text remains 'Search with Google' both before and after clicking on the input box.
   - From: `id: focused ? 'searchWithGoogle' : 'search'`
   - To: `id: 'searchWithGoogle'`

2. Updated the placeholder text in the code to reflect the expected behavior.
   - Changed `"search": "Search"` to `"search": "Search with Google"`
   - Changed `"search": "Buscar"` to `"search": "Buscar con Google"`

## Test
Verified the changes by following the steps to reproduce the issue:
1. Visit the Processing website.
2. Locate the search bar in the navigation.
3. Observed the placeholder text before and after clicking on the search input box.
4. Verified that the placeholder text remains consistent as 'Search with Google' in both states.

## Additional Notes
These changes address the placeholder text inconsistency and align the behavior with the expected outcome. The modified code ensures a better user experience on the Processing website by providing clear and consistent placeholder text in the search input.

Please review and merge these changes. If there are any concerns or questions, feel free to discuss them in the comments.

Attached a video demonstration showcasing the implemented changes. The demo illustrates the search input behavior confirming that the placeholder text now consistently displays 'Search with Google'.

https://github.com/processing/processing-website/assets/122693801/8502011e-fc92-4120-be7c-0751da2de157

