### PR TITLE
Fix issue: 487

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -22,7 +22,11 @@ export const items = [
   },
   {
     name: 'download',
-    href: '/download'
+    children: [
+      { name: 'Linux', href: '/download' },
+      { name: 'version', href: '/download/#version' },
+      { name: 'more', href: '/download/#more' }
+    ]
   },
   {
     name: 'documentation',

--- a/src/templates/download.js
+++ b/src/templates/download.js
@@ -289,7 +289,7 @@ const OSSectionContainer = memo(({ release, onAfterDownload }) => {
   const [selectedOs, setSelectedOs] = useState('');
 
   return (
-    <div className={css.osSectionContainer}>
+    <div id = "version" className={css.osSectionContainer}>
       <p>{intl.formatMessage({ id: 'otherVersions' })}</p>
       <div className={css.osSectionList}>
         {osAndComponents.map((os, index) => (
@@ -357,13 +357,14 @@ const OSSection = memo(
 
 const Link = memo(({ href, icon, title, description }) => (
   <li>
-    <a href={href}>
+    <a id = "more" href={href}>
       {icon}
       {title}
     </a>
     <p>{description}</p>
   </li>
 ));
+ 
 
 export const query = graphql`
   query($selectedReleases: [String!]!) {


### PR DESCRIPTION
## Description
Now you will be able to see children in download section which helps to get a overview of download page.

## Fixes: 

487 

## Screenshot:
![Screenshot from 2024-01-13 11-24-49](https://github.com/processing/processing-website/assets/42113006/dea9c041-157c-4cd1-aa45-6ce4187c80c8)




