### PR TITLE
Display constructor parameter types in the web reference

### DIFF
--- a/src/templates/reference/class.js
+++ b/src/templates/reference/class.js
@@ -183,6 +183,7 @@ export const query = graphql`
         parameters {
           name
           description
+          type
         }
       }
     }


### PR DESCRIPTION
The change brings the display of constructor signatures in line with how other fields (methods) are already displayed, compare:
https://github.com/processing/processing-website/blob/bf271113a486db21fc00ffd3841cb6b70adfb7c8/src/templates/reference/field.js#L172-L176

## before
![Screenshot 2024-04-15 at 23 44 01](https://github.com/processing/processing-website/assets/7602414/9a513868-4464-4795-89fb-f87622b13b09)
## after
![Screenshot 2024-04-15 at 23 45 46](https://github.com/processing/processing-website/assets/7602414/7482b950-fd82-4398-871d-e300fdd9e7a9)