### PR TITLE
Make submenus visible during keyboard navigation

### DIFF
--- a/src/components/Navbar.module.css
+++ b/src/components/Navbar.module.css
@@ -141,7 +141,9 @@
   }
 }
 
-.item:hover .submenu {
+.item:hover .submenu,
+.item:focus-visible .submenu,
+.submenu:focus-within {
   opacity: 1;
   max-height: 400px;
 }


### PR DESCRIPTION
I've noticed that the site didn't make submenus visible during keyboard navigation, making everything less intuitive.

This change shows the submenu when it has focus on it's `button` element or focus within itself.

I'm not sure if the intention behind this would be a "toggle" `button` (with it's corresponding ARIA states) instead of this, as the button currently gains focus but doesn't trigger anything on click.