### PR TITLE
Fix float.json brief description and remove periods in other brief descriptions

### DIFF
--- a/content/references/translations/en/processing/float.json
+++ b/content/references/translations/en/processing/float.json
@@ -1,6 +1,6 @@
 {
   "name": "float",
-  "brief": "Data type for floating-point numbers, e",
+  "brief": "Data type for floating-point numbers, e.g. numbers that have a decimal point",
   "description": "Data type for floating-point numbers, e.g. numbers that have a decimal point.<br />\n<br />\nFloats are not precise, so adding small values (such as 0.0001) may not always increment precisely due to rounding errors. If you want to increment a value in small intervals, use an <b>int</b>, and divide by a <b>float</b> value before using it. (See the second example above.)<br />\n<br />\nFloating-point numbers can be as large as 3.40282347E+38 and as low as -3.40282347E+38. They are stored as 32 bits (4 bytes) of information. The <b>float</b> data type is inherited from Java; you can read more about the technical details <a href=\"https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html\">here</a> and <a href=\"https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.2.3\">here</a>.<br />\n<br />\nProcessing supports the <b>double</b> datatype from Java as well. However, none of the Processing functions use <b>double</b> values, which use more memory and are typically overkill for most work created in Processing. We do not plan to add support for <b>double</b> values, as doing so would require increasing the number of API functions significantly.\n",
   "related": ["int", "double"],
   "syntax": ["float var", "float var = value"],

--- a/content/references/translations/en/processing/millis_.json
+++ b/content/references/translations/en/processing/millis_.json
@@ -1,5 +1,5 @@
 {
-  "brief": "Returns the number of milliseconds (thousandths of a second) since\n the sketch started.",
+  "brief": "Returns the number of milliseconds (thousandths of a second) since\n the sketch started",
   "related": ["second_", "minute_", "hour_", "day_", "month_", "year_"],
   "name": "millis()",
   "description": "Returns the number of milliseconds (thousandths of a second) since\n starting the sketch. This information is often used for timing animation\n sequences.\n\n ",

--- a/content/references/translations/en/processing/printArray_.json
+++ b/content/references/translations/en/processing/printArray_.json
@@ -1,5 +1,5 @@
 {
-  "brief": "Writes array data to the text\n area of the Processing environment's console.",
+  "brief": "Writes array data to the text\n area of the Processing environment's console",
   "related": ["print_", "println_"],
   "name": "printArray()",
   "description": "The <b>printArray()</b> function writes array data to the text\n area of the Processing environment's console. A new line\n is put between each element of the array. This function\n can only print one dimensional arrays.\n Note that the console is relatively slow. It works well\n for occasional messages, but does not support high-speed,\n real-time output (such as at 60 frames per second).",


### PR DESCRIPTION
The original brief description ffor `float` was cut short, so here it was fixed. The ending period for the brief description of `millis()` and `printArray()` was removed to be consistent with the other brief descriptions.