### PR TITLE
Removed explanation from license files

### DIFF
--- a/LICENSE-code
+++ b/LICENSE-code
@@ -1,5 +1,3 @@
-The following license applies to the website code written by our team and contributors from the Processing community:
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/LICENSE-content
+++ b/LICENSE-content
@@ -1,5 +1,3 @@
-The following license applies to the content of the website, including the reference and examples:
-
 Attribution-NonCommercial-ShareAlike 4.0 International
 
 =======================================================================

--- a/LICENSE-gatsby
+++ b/LICENSE-gatsby
@@ -1,5 +1,3 @@
-The following license applies to Gatsby (the framework used to build the website):
-
 The BSD Zero Clause License (0BSD)
 
 Copyright (c) 2020 Gatsby Inc.


### PR DESCRIPTION
Removed explanation from license files so that GitHub will recognize them (hopefully)