### PR TITLE
Resolved Issue with Image Overlapping on Processing.org Examples Page #514

### DIFF
--- a/src/components/character/Donate.module.css
+++ b/src/components/character/Donate.module.css
@@ -1,7 +1,7 @@
 .root {
   position: fixed;
   top: 130px;
-  right: var(--margin);
+  right: calc(var(--margin) - 1cm);
   width: var(--col1);
   float: right;
   text-align: center;

--- a/src/components/examples/ExamplesList.module.css
+++ b/src/components/examples/ExamplesList.module.css
@@ -42,7 +42,8 @@
 }
 
 .item {
-  flex-basis: calc(100% / 5);
+  flex: 0 0 calc(25% - 2 * var(--gutter)); 
+  max-width: calc(25% - 2 * var(--gutter));
 
   & h4 {
     font-size: var(--text-regular);


### PR DESCRIPTION
I have observed an issue in example page of processing website where i resolved the issue by using  4 columns instead of 5 at the largest width on the examples page, leaving space on the right.
[processingwebsitechanges.pdf](https://github.com/user-attachments/files/16281436/processingwebsitechanges.pdf)
