### PR TITLE
updated css in Navbar.module.css

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -144,7 +144,7 @@ const Navbar = ({ siteTitle, scrolled }) => {
                     </Link>
                   )
                 ) : (
-                  <button onClick={() => onClick(item.name)}>
+                  <button  onClick={() => onClick(item.name)}>
                     {intl.formatMessage({ id: item.name })}
                   </button>
                 )}

--- a/src/components/Navbar.module.css
+++ b/src/components/Navbar.module.css
@@ -76,16 +76,18 @@
   font-size: var(--text-medium);
   font-weight: 600;
   white-space: nowrap;
+
   & button,
   & a {
     padding: 0 0.75rem;
-
     display: block;
     font-weight: inherit;
     line-height: 1.5;
     color: var(--processing-blue-dark);
   }
-  & a:hover {
+
+  & a:hover,
+  & button:hover {
     color: var(--processing-blue-mid);
   }
 }
@@ -98,9 +100,12 @@
 .active {
   border-left: solid 4px var(--processing-blue-dark);
 }
+
 .item.hasSubmenu:hover {
-  border-left: solid 4px var(--processing-blue-dark);
+  border-left: solid 4px var(--processing-blue-mid);
 }
+
+
 .submenu {
   display: flex;
   position: absolute;


### PR DESCRIPTION
Issue:
In the navigation bar, items with submenus (.item.hasSubmenu) were not receiving the same hover effect as those without submenus. Specifically, the buttons used in .item.hasSubmenu were not styled consistently with the anchor tags in other items. This resulted in an inconsistent user experience where items with submenus appeared differently when hovered over compared to items without submenus.

Cause:
The original CSS provided styling for .item and its anchor tags, but did not include styles for buttons within .item.hasSubmenu. As a result, the buttons lacked the same hover effects and other styles as the anchor tags, causing visual inconsistency in the navigation bar.

Solution:
To resolve this, I updated the CSS to include styles for buttons within .item.hasSubmenu, ensuring they have the same hover effects and other styles as the anchor tags.
![Screenshot 2024-08-07 235656](https://github.com/user-attachments/assets/c53b7261-b1d3-476f-ac4f-f60470ad3137)
