### PR TITLE
Fixed semicolon in TWO_PI.pde

### DIFF
--- a/content/references/examples/processing/TWO_PI/TWO_PI.pde
+++ b/content/references/examples/processing/TWO_PI/TWO_PI.pde
@@ -1,7 +1,7 @@
 float x = width/2;
 float y = height/2;
 float d = width * 0.8;
-size(400,400)；
+size(400,400);
 arc(x, y, d, d, 0, QUARTER_PI);
 arc(x, y, d-80, d-80, 0, HALF_PI);
 arc(x, y, d-160, d-160, 0, PI);


### PR DESCRIPTION
The previous character is not a semicolon.  It just looks like one.  The ASCII code for a semicolon is 59.  I checked the code for whatever is currently after the size(400,400) and I found 65307.  

'；'.charCodeAt(0)

I discovered this issue when pasting code from the example on the Processing website.