### PR TITLE
feat: Implemented border when hover

### DIFF
--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -112,7 +112,6 @@
 
 .tocItem {
   margin-bottom: 1rem;
-  padding-left: calc(var(--gutter) + 0.5rem); 
 
   & a {
     font-family: var(--font);

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -50,6 +50,7 @@
   flex-grow: 1;
   position: relative;
   overflow-y: auto;
+  padding-top: 1rem; 
   & ul li h4 {
     text-wrap: pretty;
   }
@@ -110,20 +111,29 @@
 }
 
 .tocItem {
+  margin-bottom: 1rem;
+  padding-left: calc(var(--gutter) + 0.5rem); 
+
   & a {
     font-family: var(--font);
     text-overflow: ellipsis;
     color: var(--processing-blue-dark);
+    border-left: 4px solid transparent;
+    display: flex;
+    align-items: center;
+    padding: 3px 0.75rem;
+    transition: color 0.3s, border-left-color 0.3s;
+
     &:hover {
       color: var(--processing-blue-mid);
+      border-left-color: var(--processing-blue-mid);
     }
+
   }
 
   & h4 {
     font-size: var(--text-regular);
     color: inherit;
-    &:hover {
-      color: inherit;
-    }
+    margin: 0;
   }
 }

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -30,7 +30,7 @@
 .title {
   font-size: var(--text-reduced);
   padding-top: 20px;
-  text-wrap: pretty;
+  overflow-wrap: break-word; 
 }
 
 .toggleButton {


### PR DESCRIPTION
feat: Highlight or add left border to active navbar subitem
#487  - added the feature.

In the issue the problem was not mentioned properly(the download nav item gets a left border for distinction. The same can apply to nav sub-items.) but it seems it indicates navs under the "Table of Contents" section must display the same left border upon selection.

How to see the changes
Go to documentation.
Go the environment.
Now move your mouse over the contents of the table.
Here is the Screenshot

https://github.com/user-attachments/assets/11b41247-7e40-4d94-83b8-198a506df17e

