### PR TITLE
Add strokeWeight to reference in point_ 

### DIFF
--- a/content/references/translations/en/processing/point_.json
+++ b/content/references/translations/en/processing/point_.json
@@ -1,8 +1,8 @@
 {
   "brief": "Draws a point, a coordinate in space at the dimension of one pixel",
-  "related": ["stroke_"],
+  "related": ["stroke_", "strokeWeight_"],
   "name": "point()",
-  "description": "Draws a point, a coordinate in space at the dimension of one pixel. The first\n parameter is the horizontal value for the point, the second value is the\n vertical value for the point, and the optional third value is the depth\n value. Drawing this shape in 3D with the <b>z</b> parameter requires the P3D\n parameter in combination with <b>size()</b> as shown in the above example.\n <br/>\n <br/>\n Use <b>stroke()</b> to set the color of a <b>point()</b>. <br/>\n <br/>\n Point appears round with the default <b>strokeCap(ROUND)</b> and square with\n <b>strokeCap(PROJECT)</b>. Points are invisible with <b>strokeCap(SQUARE)</b>\n (no cap). <br/>\n <br/>\n Using point() with strokeWeight(1) or smaller may draw nothing to the screen,\n depending on the graphics settings of the computer. Workarounds include\n setting the pixel using <b>set()</s> or drawing the point using either\n <b>circle()</b> or <b>square()</b>.",
+  "description": "Draws a point, a coordinate in space at the dimension of one pixel. The first\n parameter is the horizontal value for the point, the second value is the\n vertical value for the point, and the optional third value is the depth\n value. Drawing this shape in 3D with the <b>z</b> parameter requires the P3D\n parameter in combination with <b>size()</b> as shown in the above example.\n <br/>\n <br/>\n Use <b>stroke()</b> to set the color of a <b>point()</b>. <br/>\n <br/>\n Point appears round with the default <b>strokeCap(ROUND)</b> and square with\n <b>strokeCap(PROJECT)</b>. Points are invisible with <b>strokeCap(SQUARE)</b>\n (no cap). <br/>\n <br/>\n Using point() with <b>strokeWeight(1)</b> or smaller may draw nothing to the screen,\n depending on the graphics settings of the computer. Workarounds include\n setting the pixel using <b>set()</s> or drawing the point using either\n <b>circle()</b> or <b>square()</b>.",
   "syntax": ["point(x, y)", "point(x, y, z)"],
   "returns": "void",
   "type": "function",


### PR DESCRIPTION
### Issue Fixed: **This update improves clarity for users looking to understand how strokeWeight() impacts the point() function.**
### Fixes #609 

**Description:**
This PR adds missing documentation for the strokeWeight() function in the reference section of the point() function.

**Changes Made:**

- Updated the point() reference to include details about strokeWeight().
- Clarified how strokeWeight() affects the appearance of points in the drawing canvas.
- Ensured consistency with other function references in the documentation.

### Screenshot
**_Previously_**




![Previously](https://github.com/user-attachments/assets/17bb4649-ac61-4b27-9514-5a7bacfa16bb)

**_After_**

![After](https://github.com/user-attachments/assets/f643b721-636b-4e8a-b564-7fe64978d18d)
