### PR TITLE
RE: #633 Reference Processing CLI in Tools

### DIFF
--- a/content/tools/processing-cli/processing-cli.es.json
+++ b/content/tools/processing-cli/processing-cli.es.json
@@ -1,0 +1,4 @@
+{
+  "name": "Processing CLI",
+  "description": ""
+}

--- a/content/tools/processing-cli/processing-cli.json
+++ b/content/tools/processing-cli/processing-cli.json
@@ -1,0 +1,4 @@
+{
+  "name": "Processing CLI",
+  "description": "Processing from the command line. (Run `./Processing cli --help` on the Processing executable within the application bundle)"
+}

--- a/content/tools/processing-cli/processing-cli.json
+++ b/content/tools/processing-cli/processing-cli.json
@@ -1,4 +1,4 @@
 {
   "name": "Processing CLI",
-  "description": "Processing from the command line. (Run `./Processing cli --help` on the Processing executable within the application bundle)"
+  "description": "Processing from the command line. (Run `./Processing --help` on the Processing executable within the application bundle)"
 }


### PR DESCRIPTION
PR to address Issue #633 Reference Processing CLI in Tools

This is a first pass of mentioning the Processing CLI on the Processing website. The full functionality of the CLI is covered by running --help, so the purpose of this change is more to share the existence of the CLI functionality. 

Help Needed:
- I'm not sure how to format the command to look like code within the context of the json file.
- There is no Spanish translation yet. Once the English copy is approved, I could ask a friend who speaks Spanish to help translate?