### PR TITLE
Mention CLI on Processing website's Environment Section

### DIFF
--- a/content/pages/environment/index.mdx
+++ b/content/pages/environment/index.mdx
@@ -565,3 +565,12 @@ Add contributed Examples by first opening the "Examples..." submenu from the Fil
 ## Export
 
 The [Export information and Tips](https://github.com/processing/processing/wiki/Export-Info-and-Tips) page on the Processing Wiki covers the details of exporting Applications from Java mode.
+
+## Command Line Interface (CLI) 
+
+Run sketches from the terminal using Processing's Command Line Interface (CLI).    
+To view a list of available commands, open a terminal and run:
+```
+./Processing --help
+```
+Run this command from the directory containing the Processing executable. For example, on macOS, the executable is usually located at /Applications/Processing.app/Contents/MacOS/Processing.


### PR DESCRIPTION
Added CLI explanation to the bottom of the environment section to address issue about CLI not being available in the documentation #633 and previous attempt to mention it in Tools #634 