### PR TITLE
Configure Netlify redirects for Processing domains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # Netlify redirects
 # 1. To add a subdomain, add a redirect in this file first and merge the PR
-# 2. Add the subdomain to the Processing website in netlify
+# 2. Add the subdomain to the Processing website in netlify by going to Domain Management -> Production Domains -> Add domain alias
 
 [[redirects]]
   from = "https://wiki.processing.org/*"


### PR DESCRIPTION
This unifies the process for setting up redirect subdomains (and path redirects for that matter, e.g. https://processing.org/my-fancy-link) 

Please let me know if the instructions make sense and are clear enough