### PR TITLE
Add Discord link to footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -23,7 +23,7 @@ const Footer = ({ withSidebar }) => {
             <a href={'http://github.com/processing/'} target="_blank" rel="noreferrer">GitHub</a>
           </li>
           <li>
-            <a href={'https://discord.gg/aWTgcaGdjr'} target="_blank" rel="noreferrer">Discord</a>
+            <a href={'https://discord.gg/mt2CnebPsJ'} target="_blank" rel="noreferrer">Discord</a>
           </li>
           <li>
             <a href={'https://bsky.app/profile/processing.org'} target="_blank" rel="noreferrer">Bluesky</a>


### PR DESCRIPTION
A new Discord link has been added to the footer navigation

<img width="1055" height="233" alt="image" src="https://github.com/user-attachments/assets/2173b065-dd50-47d3-92f9-590cea512326" />