### PR TITLE
Fix Accessibility Violations in Partner Logos Section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -282,14 +282,15 @@ const IndexPage = ({ data }) => {
                       className={css.logo}
                       href={url}
                       target="_blank"
-                      rel="noreferrer">
+                      rel="noreferrer"
+                      aria-label={name}>
                       {typeof Logo === 'string' ? (
                         <GatsbyImage
                           image={data[Logo].childImageSharp.gatsbyImageData}
                           alt={name}
                         />
                       ) : (
-                        <Logo />
+                        <Logo aria-hidden="true" />
                       )}
                     </a>
                   </li>


### PR DESCRIPTION
### Problem

The [IBM Equal Access Accessibility Checker](https://github.com/IBMa/equal-access) detected two accessibility violations in the partner logos section of [homepage](https://processing.org/):

- Missing accessible name for links: Hyperlinks must have an accessible name for their purpose
- SVG elements missing accessible name: Non-decorative SVG elements must have an accessible name

<img width="2560" height="923" alt="image" src="https://github.com/user-attachments/assets/04723f7f-ae50-4de6-be96-eaf94c1ebfbb" />

### Solution
This patch addresses both violations by:

- Adding `aria-label` to link elements: Each partner logo link now includes an `aria-label={name}` attribute, providing a clear accessible name that describes the link's purpose (e.g., "DMA", "ITP", "Netlify", "GitHub Sponsors")
- Marking SVG logos as decorative: When the Logo component is rendered as an SVG, it now includes `aria-hidden="true"` to indicate it's decorative, since the accessible name is already provided by the parent link's `aria-label`

**Generated Patch:**
``` diff
@@ -282,14 +282,15 @@ const IndexPage = ({ data }) => {
                       className={css.logo}
                       href={url}
                       target="_blank"
-                      rel="noreferrer">
+                      rel="noreferrer"
+                      aria-label={name}>
                       {typeof Logo === 'string' ? (
                         <GatsbyImage
                           image={data[Logo].childImageSharp.gatsbyImageData}
                           alt={name}
                         />
                       ) : (
-                        <Logo />
+                        <Logo aria-hidden="true" />
                       )}
                     </a>
```

The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.

**Fix Before:**
<img width="498" height="221" alt="image" src="https://github.com/user-attachments/assets/7e2ecb59-70b7-4555-8925-095094f55fbc" />

**Fix After:**
<img width="490" height="234" alt="image" src="https://github.com/user-attachments/assets/9bbcf05d-0c26-4ba6-bf57-14f9e4eb14f9" />

### Testing

✅ IBM Equal Access Accessibility Checker now shows 0 violations (previously 2)
✅ Screen readers can now properly announce partner links
✅ Visual appearance remains unchanged

### Impact
This fix improves accessibility for users relying on assistive technologies, ensuring all partner links are properly labeled and announced by screen readers.