### PR TITLE
Community survey: update sitewide banner message and make it visible

### DIFF
--- a/content/sitewide/banner.json
+++ b/content/sitewide/banner.json
@@ -1,5 +1,5 @@
 {
-  "visible": false,
-  "text": "Donate Today! Support Processing and the Processing Foundation.",
-  "url": "https://processingfoundation.org/donate"
+  "visible": true,
+  "text": "Have a few minutes? Take the community survey and share your thoughts about Processing.",
+  "url": "https://survey.processing.org"
 }


### PR DESCRIPTION
Changed the banner to be visible and updated the text and URL to promote the community survey instead of the donation campaign.