### PR TITLE
Update macOS Processing CLI instructions

### DIFF
--- a/content/pages/environment/index.mdx
+++ b/content/pages/environment/index.mdx
@@ -584,8 +584,7 @@ processing --help
 
 *macOS*
 ```
-cd /Applications/Processing.app/Contents/MacOS
-./Processing --help
+processing --help
 ```
 
-_**Note:** On macOS, the executable lives inside the `.app` bundle, so that's why there is a command to navigate to it's folder first. On Windows and Linux, Processing is typically added to your PATH by default, so no navigation is needed._
+_**Note:** On macOS, the CLI is not installed by default, run `tools -> install "processing" from Processing.  On Windows and Linux, Processing is typically added to your PATH by default, so no installation is needed._

--- a/content/pages/environment/index.mdx
+++ b/content/pages/environment/index.mdx
@@ -577,12 +577,7 @@ Make sure Processing is installed, then run the help command to see all availabl
 processing --help | more
 ```
 
-*Linux*
-```
-processing --help
-```
-
-*macOS*
+*macOS/Linux*
 ```
 processing --help
 ```


### PR DESCRIPTION
Replace previous instructions that required navigating into the .app bundle and running the binary with a simpler `processing --help` example. Clarify that the CLI is not installed by default on macOS and must be added via Tools → Install "processing" from the Processing app, while Windows and Linux typically have Processing on the PATH by default.

Merge with the next version of Processing