### PR TITLE
Add generic ErrorPage and 429 handling

### DIFF
--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -437,5 +437,8 @@
   "Request Image": "Request Image",
   "Background Image": "Background Image",
   "Datatype Conversion": "Datatype Conversion",
+  "tooManyRequestsTitle": "Too many requests",
+  "tooManyRequests": "TOO MANY REQUESTS",
+  "tooManyRequestsText": "You've made too many requests in a short period. Please wait a moment and try again.",
   " ": ""
 }

--- a/i18n/react-intl/es.json
+++ b/i18n/react-intl/es.json
@@ -437,5 +437,8 @@
   "Request Image": "Solicitar Imagen",
   "Background Image": "Imagen de Fondo",
   "Datatype Conversion": "Conversión de Tipos de Datos",
+  "tooManyRequestsTitle": "Demasiadas solicitudes",
+  "tooManyRequests": "TOO MANY REQUESTS",
+  "tooManyRequestsText": "Has realizado demasiadas solicitudes en poco tiempo. Por favor, espera un momento e inténtalo de nuevo.",
   " ": ""
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,8 @@
   from = "/*"
   to = "/:splat"
     [redirects.rate_limit]
+    action = "rewrite"
+    to = "/429/"
     window_limit = 50
     window_size = 60
     aggregate_by = ["ip", "domain"]

--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useIntl } from 'react-intl';
+
+import Layout from './Layout';
+import * as css from '../styles/pages/error.module.css';
+
+const ErrorPage = ({ titleId, headingId, textId }) => {
+  const intl = useIntl();
+
+  return (
+    <Layout>
+      <Helmet>
+        <title>{intl.formatMessage({ id: titleId })}</title>
+      </Helmet>
+      <div className={css.error}>
+        <h1>{intl.formatMessage({ id: headingId })}</h1>
+        <p>{intl.formatMessage({ id: textId })}</p>
+      </div>
+    </Layout>
+  );
+};
+
+export default ErrorPage;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,24 +1,12 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
-import { useIntl } from 'react-intl';
+import ErrorPage from '../components/ErrorPage';
 
-import Layout from '../components/Layout';
-import * as css from '../styles/pages/404.module.css';
-
-const NotFoundPage = () => {
-  const intl = useIntl();
-
-  return (
-    <Layout>
-      <Helmet>
-        <title>{intl.formatMessage({ id: 'pageNotFound' })}</title>
-      </Helmet>
-      <div className={css.notfound}>
-        <h1>{intl.formatMessage({ id: 'notFound' })}</h1>
-        <p>{intl.formatMessage({ id: 'notFoundText' })}</p>
-      </div>
-    </Layout>
-  );
-};
+const NotFoundPage = () => (
+  <ErrorPage
+    titleId="pageNotFound"
+    headingId="notFound"
+    textId="notFoundText"
+  />
+);
 
 export default NotFoundPage;

--- a/src/pages/429.js
+++ b/src/pages/429.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ErrorPage from '../components/ErrorPage';
+
+const TooManyRequestsPage = () => (
+  <ErrorPage
+    titleId="tooManyRequestsTitle"
+    headingId="tooManyRequests"
+    textId="tooManyRequestsText"
+  />
+);
+
+export default TooManyRequestsPage;

--- a/src/styles/pages/error.module.css
+++ b/src/styles/pages/error.module.css
@@ -1,3 +1,3 @@
-.notfound {
+.error {
   padding: var(--margin);
 }


### PR DESCRIPTION
Introduce a reusable ErrorPage component and refactor the existing 404 page to use it. Add a new 429 page for "Too Many Requests" and include English and Spanish localized messages. Update netlify.toml to rewrite rate_limit hits to /429/. Rename CSS module from 404.module.css to error.module.css and adjust the class from .notfound to .error.