### PR TITLE
Add link to library template on libraries page

### DIFF
--- a/i18n/react-intl/en.json
+++ b/i18n/react-intl/en.json
@@ -108,6 +108,7 @@
   "librariesFilter": "Filter by keywords...",
   "contributions": "Contributions",
   "contributionsIntro": "Contributed libraries are created by members of the Processing community. They are independently and generously created to share. They are all open source and include their own reference and examples.",
+  "librariesTemplate": "Ready to contribute? Learn how to <a href='https://processing.github.io/processing-library-template/getting-started.html' target='_blank' rel='noreferrer'>create a Processing library</a>.",
   "referencesFilter": "Filter by keywords...",
   "toolsIntro": "The following tools are included with the Processing software. Select the tool you want to use from the Tools menu of the Processing Environment. These tools are open source; the code is distributed with Processing.",
   "contributedTools": "Contributed tools must be downloaded individually. Select 'Add Tool...' from the Tools menu to select a Tool to download. Contributed tools are developed, documented, and maintained by members of the Processing community. For feedback and support, please post to the <a href='http://forum.processing.org/'>Forum</a>. For development discussions post to the <a href='http://forum.processing.org/library-and-tool-development'> Libraries and Tool Development </a> topic. Instructions for creating your own tool are on the <a href='https://github.com/processing/processing/wiki'> Processing GitHub </a> site.",

--- a/src/templates/reference/libraries/index.js
+++ b/src/templates/reference/libraries/index.js
@@ -56,6 +56,12 @@ const Libraries = ({ data, pageContext }) => {
         <div className={classnames(grid.col, css.text, css.pushDown)}>
           <h1>{intl.formatMessage({ id: 'contributions' })}</h1>
           <h3>{intl.formatMessage({ id: 'contributionsIntro' })}</h3>
+          <p></p>
+          <p
+            dangerouslySetInnerHTML={{
+              __html: intl.formatMessage({ id: 'librariesTemplate' })
+            }}
+          />
         </div>
         <div className={classnames(grid.col, css.filter)}>
           <FilterBar


### PR DESCRIPTION
This pull request adds a call-to-action to the Libraries reference page, linking to the [Getting Started page](https://processing.github.io/processing-library-template/getting-started.html) on the library template website.

<img width="1152" height="678" alt="image" src="https://github.com/user-attachments/assets/d137c47b-d934-476b-b229-c6073b3cf132" />